### PR TITLE
Power autogen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-# Monastery Test
+# SPDX
 
-- Fleshed out the Monastery test-module substantially.
-- Work in the *Raptor Protectorate* and *Shaded Sea*.
-- Other minor changes throughout.
+- adding an spdx file (it feels like we shouldn't be doing this if we aren't a binary package)
+  - Turns out, on reflection, we don't actually care.
+    So I'm not doing that.
+- Updated the LICENSE file.
+- Minor edits in the README.
+- Updated 00-about-the-game to link to the github and include the license (otherwise, if you just visited the site, you'd have no idea).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,4 +2,6 @@ Copyright (c) David S Bolding (boldingd@gmail.com).
 
 Licensed under the [Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)](https://creativecommons.org/licenses/by-nc/4.0/) license.
 
-The code for the website and the site generator is (c) Alexis Williams (alexis@typedr.at) and are licensed under the [Mozilla Public License, version 2.0](https://www.mozilla.org/en-US/MPL/2.0/).
+The code for the initial version of the website and its site generator is (c) Alexis Williams (alexis@typedr.at) and are licensed under the [Mozilla Public License, version 2.0](https://www.mozilla.org/en-US/MPL/2.0/), as is the supporting code for the *gatsby* version of the site.
+
+The supporting code for the mdbook version, as well as some supporting scripts, is copyright David Bolding, and licensed under the [Mozilla Public License, version 2.0](https://www.mozilla.org/en-US/MPL/2.0/).

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ They have a significant command of magic, and a technology very roughly tracking
 THey are a peaceful and prosperous nation.
 
 Some of their neighbors are less so, tho: the Kingdoms of Man is riven with internal conflict, the Shaded Sea Peoples are piratical raiders, and the Goblin Kingdoms are slavers and worse.
-Perhaps worse are the Spirits--the world of Renaissance is alive with spirits: some are closely aligned with the Commonwealth, reguarding mortals as allies and friends; others are aloof, but are willing to offer service in exchange for propitiation; still others are either actively hostile, or completely aloof and inscrutable.
+Perhaps worse are the Spirits – the world of Renaissance is alive with spirits: some are closely aligned with the Commonwealth, reguarding mortals as allies and friends; others are aloof, but are willing to offer service in exchange for propitiation; still others are either actively hostile, or completely aloof and inscrutable.
 
 In terms of play, Renaissance leans away from dungeon-crawling: D&D is already an excellent take on that.
-It leans towards intrigue campaigns--investigating slave rings, busting smugglers and infiltrating neighboring kingdoms.
-Largely because of its Eclipse Phase heritage, it also handles horror well, driven by malevolant spirits--creating a style of play that might be called "Fantasy Call of Cthulhu".
+It leans towards intrigue campaigns – investigating slave rings, busting smugglers and infiltrating neighboring kingdoms.
+Largely because of its Eclipse Phase heritage, it also handles horror well, driven by malevolent spirits – creating a style of play that might be called "Fantasy Call of Cthulhu".
 
 It is based loosely on the rules from Eclipse Phase, Version 1.
 (Which is an excellent game that is well worth playing).
-It's released under the Creative Commons Attribution-Noncommercial 4.0 license.
 
-This is obviously a very early draft: it's still a bullet list.
+This is obviously a very early draft: we're missing a lot, we've got some inconsistencies and errors, we've got two different candidate versions of some things posted, it's still a bullet list in some places…
 We're still working on getting the rules in place.
 If you feel like giving it a playtest or submitting feedback, please do.
 
 The RPG was initially written by and is copyright of David Bolding (boldingd@gmail.com), with significant contributions from Alexis Williams and other.
+The game is released under an open license; see the LICENSE.md file.

--- a/src/chapters/00-about-the-game.md
+++ b/src/chapters/00-about-the-game.md
@@ -3,24 +3,26 @@
 ![Commonwealth Banner](../images/proto_banner_cw_raaad.jpg)
 
 This is an early alpha of an open-source fantasy RPG.
+It's hosted on [GitHub](https://github.com/renaissance-publishing/renaissance/), and [licensed](https://github.com/renaissance-publishing/renaissance/blob/source/LICENSE.md) under the [Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)](https://creativecommons.org/licenses/by-nc/4.0/) license.
 
 We're working on it.
 We've got a lot of the mechanics in a fairly good place, at least for what we want to do, and most of the "core" player options are present.
 Now we just need to take all the long bullet-lists and convert them to full English text.
 And also write in all the background stuff that's in my (the lead author's) head but that has never been written down anywhere.
-
 And make sure all the revisions and rule-versions are consistent.
-
 And also add more player content and options.
 
-We're working on it.
+Well… we're working on it.
 
 ## Changes since last time:
 
 - Removed Disable Device, because we've never used it.
+- Fleshed out the *Monastery* sample adventure a fair bit.
 - Initial import for CV's *Wolf-in-Wool's Flock*, AKA the Secret Army, and his Stormsword's Rest.
   - Stormsword's Rest has been waiting... how many years?
     I'm so sorry.
+- Moved to a whole different site-generator (mdbook), which loses us a few things, but gains us search and a great mobile layout.
+- Broke the Races and Other Nations chapters into sub-chapters (that's a neat feature we get for almost-free with mdbook).
 
 ## To-Do
 

--- a/src/chapters/27-powers.md
+++ b/src/chapters/27-powers.md
@@ -631,11 +631,11 @@ You have developed a kind of battle-trance, in which your combat instincts are h
 While centered, you strike with extra force.
 
 - **Requirements:** the *Center* power, 20 ranks in Control
-- **Effect:** WhilStance | You adopt a e sustaining Center, You gain +Trance Bonus to your DV.
+- **Effect:** While sustaining Center, You gain +Trance Bonus to your DV.
 
 #### Centered Defence
 
-While centered, your defence is improved.
+While centered, your defense is improved.
 
 - **Requirements:** the *Center* power, 20 ranks in Control, 10 ranks in Fray
 - **Effect:** While sustaining *Center*, you gain +10 to your defence.

--- a/src/chapters/27-powers.md
+++ b/src/chapters/27-powers.md
@@ -326,6 +326,22 @@ You've practice an unusual tactic in which you fling an ally at an enemy; this i
 Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action).
 - **Special:** If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*
 
+### Hurl an Ally
+
+You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands.
+
+- **Requires:** The *Missile-Hurler* class.
+- **Action:** Standard Action
+- **Effect:** You can throw an ally.
+  - They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
+  - If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
+  - If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
+  - If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
+  - They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn.
+- **Special:** This power represents *throwing* an ally, which is a Standard Action.
+Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action).
+- **Special:** If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*
+
 ### Imbue
 
 - **Requires:** Eidolon, 20 ranks in Control
@@ -384,6 +400,21 @@ If you loose physical contact with the target, the power ends.
 - **Effect:** You can use your own intrinsic magic to control (and fortify) your own life processes.
   - While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
   - While sustaining this power, you gain +1 Armor.
+
+### Parry with the Sheath
+
+Useful for more than just holding the weapon.
+
+- **Requires:** 10 Ranks in Fray, 10 ranks in Melee Combat
+- **Action:** Reaction
+- **Effect:** When you are attacked in melee, as a reaction, you can add +20 to your defense check.
+  - You are considered to be armed while defending in this way.
+- **Clarification:** You must declare the use of this power before you roll your defense.
+Normally, you get one reaction per "turn-cycle".
+This power is useful any time you defend, whether you're using fray, taking the full defense action, moving evasively, parrying, or doing something else.
+- **Special:** To use this power, you must name a sturdy item that you are carrying, that you could grab quickly; good candidates include sheathes, walking sticks, and cooking pans.
+  - The GM must approve of this choice.
+  - If you critically fail on your defense, you drop the item you picked.
 
 ### Pilot
 
@@ -477,6 +508,15 @@ You are expert in the use of large shields, and your defence with them is extrao
 - **Requires:** 10 ranks in an Attack skill.
 - **Effect:** You are particularly good at striking weak spots.
 When you attack an unaware or helpless target, you inflict an additional 1d10 DV.
+
+### Take the Blow
+
+If you're gonna get stabbed, you'd rather the blade turn on your ribs than pass between them.
+
+- **Requires:** 20 Ranks in Fray
+- **Action:** Automatic
+- **Effect:** While taking the *full defense* action, whenever you defend with fray, you gain +1 armor per 10 points of MoS.
+- **Special:** You do not gain this benefit if you are wearing armor with the cumbersome or heavy tags, or carrying a shield with the cumbersome or heavy tags.
 
 ### Transfer
 

--- a/src/chapters/27-powers.md
+++ b/src/chapters/27-powers.md
@@ -72,506 +72,351 @@ Since powers are actions, they will also list the *type* of action that they req
 |
 |Of course, a player who wants an *ice attack* power doesn't *have to* create it by modifying the Fireball power; with your approval, they could make their own *ice blast* or *ice javelin* power — or whatever else they want.
 
-  - Fireball: You can manifest a fireball in your hand.
-    
-      - Requires: 10 ranks in Spellcraft
-    
-      - Action: Quick Action
-    
-      - Effect: held ball of fire
-        
-          - After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
-          - If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
-          - You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
-          - The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
-          - Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag).
 
-  - Exploding Fireball:
-    
-      - Requires: Fireball and 20 ranks in Spellcraft
-      - When using the Fireball power, when your fireball expires
-        (either because you dismissed it or because it left contact with
-        you), you may choose to have it explode. Treat this as a Blast
-        effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)
+### Acrobatic Strike
 
-  - Intense Fire:
-    
-      - Requires: 20 ranks in Spellcraft
-      - Effect: Your fire spells do an additional 1d10 DV of damage and
-        have AP -1.
+By kicking off walls, flipping over obstacles or otherwise acrobatically exploiting your environment, you can build up a lot of momentum in a short space.
 
-  - Jump
-    
-      - Requires: 10 ranks in Spellcraft
-      - Action: Quick Action
-      - Effect: You teleport, moving up to twice your Running movement.
+- **Requires:** 20 ranks in Athletics, 10 ranks in a *melee combat* skill.
+- **Action:** Varies (stunt, movement)
+- **Effect:** When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
+  - An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle.
 
-  - Group Jump
-    
-      - Requires: Jump, 20 ranks in Spellcraft
-      - Effect: when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft.
+### Blank
 
-  - Long Jump
-    
-      - Requires: Jump, 20 ranks in Spellcraft
-      - Action: Standard Action
-      - Effect: You teleport, moving up to 10 times your Running movement.
+- **Requires:** 20 Ranks in Deception
+- **Action:** Sustained
+- **Effect:** Though it requires some concentration, you have an uncanny ability to blank your expression, replacing it with pleasant neutral demeanor.
+  - While sustaining this power, Read checks made against you suffer a -30 penalty.
+  - However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks.
 
-  - Journey
-    
-      - Requires: Long Jump, 30 ranks in Spellcraft
-      - Action: Task Action (1 minute)
-      - Effect: You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft.
+### Blur
 
-  - Pilot
-    
-      - Requires: Journey, Group Jump
-      - Action: Task Action (10 minutes)
-      - Effect: You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network.
+- **Requires:** 10 Ranks in Spellcraft, 10 Ranks in Stealth
+- **Action:** Sustained
+- **Effect:** You become translucent, making you hard to spot.
+  - You gain +10 bonus to Stealth checks to avoid being seen.
+- **Special:** The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it.
 
-  - Master
-    
-      - Requires: 10 Control
-    
-      - Action: Sustained
-    
-      - Effect: You can use your own intrinsic magic to control (and fortify) your own life processes.
-        
-          - While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
-          - While sustaining this power, you gain +1 Armor.
+### Bound Fighter
 
-  - Down-Time
-    
-      - Requires: Transcend, 20 Control
-    
-      - Action: 4-Hour Task Action
-    
-      - You can enter a deep, meditative state, in which you can
-        nourish, refresh and repair both your mind and body.
-    
-      - Effect:
-        
-          - After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
-          - After completing the Sleight, you recover 1d10÷3 Stress.
-          - While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day.
-          - Special: if you have the Heal Sleight, you may also sustain it during Down Time.
+Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up.
 
-  - Fortify
-    
-      - Requires: 20 Control
-    
-      - Action: Sustained
-    
-      - Effect: you can fortify your physical and mental abilities.
-        
-          - While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
-          - (Your derived stats would also change, as normal.)
+- **Requires:** 20 ranks in Unarmed Combat
+- **Action:** Standard Action
+- **Effect:** When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack.
+- **Special:** You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden.
+- **Special:** Critical hits with this attack may weaken or break weaker bindings, like ropes.
 
-  - Heal
-    
-      - Requires: 10 Control
-    
-      - Action: Sustained
-    
-      - Effect: Your wounds begin to heal.
-        
-          - While sustaining this power, you have Fast Healing 1.
-          - While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2.
-          - Special: if you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check.
+### Brawler's Instinct
 
-  - Transfer
-    
-      - Requires: 10 Control
-    
-      - Action: Sustained
-    
-      - Condition: To use this power, you must be touching one other
-        creature (which must have a DUR rating).
-    
-      - Effects: You transfer wounds from a creature that you touch to
-        yourself.
-        
-          - For every turn that you sustain this power, you take 2 DV;
-            if you do, the creature you are touching is either healed
-            healed for 2 DUR, or one ongoing bleed effect is ended (you
-            choose which).
-          - This power cannot “transfer” wounds in this way, nor can it
-            heal diseases, congenital defects or poisons.
+Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight.
 
-  - Regrowth
-    
-      - Requires: Heal, 20 Control
-      - Action: Task Action (1 Hour)
-      - Effect: Roll a Control check. If you succeed, you heal one
-        wound.
+- **Requires:** 10 ranks in Perception, 10 ranks in two *combat* skills.
+- **Effect:** You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you.
 
-  - Sacrifice
-    
-      - Requires: Transfer, 20 Control
-      - Action: Task Action (1 minute)
-      - Condition: To use this power, you must be sustaining Transfer
-      - Effect: You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound.
-        (Note: the wound is not *bound*, it is entirely healed.)
-      - Using sacrifice can be stressful.
-        A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted.
+### Brawler's Sense
 
-  - Join
-    
-      - Requires: 10 Ranks in Control
-      - Action: Sustained
-      - Condition: To use this Power, you must be touching one
-        character; this character is the target of the Power. If you
-        loose physical contact with the target, the power ends.
-      - Effect: You join minds with the target, creating a Gestalt.
-        Normally, this is an equal blending; however, under some
-        circumstances – particularly if the target is unwilling – the
-        two minds might fight for dominance over the Gestalt. Treat this
-        as an opposed WIL&times;3 check, with the winner gaining dominance,
-        and thereafter being able to direct the actions of the gestalt.
-      - The gestalt mind has access to the skills, knowledge and
-        memories of both individuals. The gestalt mind will also express
-        the desires of both minds – even if one mind has become
-        dominant, the other mind in the Gestalt cannot be suppressed
-        completely.
-      - Unsurprisingly, this can be extremely traumatic – this is almost
-        always the case when the target is unwilling.
-      - Physical action is very difficult, given that one character must
-        maintain physical contact with another – but it can be
-        attempted. Appropriate penalties apply (usually -30).
-      - For simplicity, assume that the Gestalt functions as one
-        character, at least in so far as it has one initiative score and
-        has the same allotment of actions that any individual character
-        would have.
+Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has...
 
-  - Link
-    
-      - Requires: Join, 20 Ranks in Control
-      - Action: Task Action (5 minutes)
-      - Condition: To use this power, you must be sustaining Join.
-      - While sustaining Join, you can Link your mind with the target.
-        Thereafter, as long as you continue to sustain Join, you can
-        break physical contact with the target and maintain the Gestalt.
-        This makes physical action far more feasible.
-      - The targets cannot get more than (Your ranks in Control)&times;2
-        meters apart from one-another, or the effect ends.
+- **Requires:** 20 ranks in Perception, 20 ranks in Unarmed Combat
+- **Action:** Sustained
+- **Effect:** While sustaining this power, you gain *Brawler's Sense* as a sense.
+  - This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
+  - This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
+  - What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty.
 
-  - Collective
-    
-      - Requires: Join, Link, 30 Ranks in Control
-      - Condition: You must be sustaining Join, and you must have Linked
-        with the target.
-      - You can incorporate more than one mind into the Gestalt created
-        by Join. To add a new mind, you must use Join on that mind, and
-        you must then Link that mind.
-      - To remain in the Gestalt, ever element of the collective must be
-        within the given range of at least one other element of the
-        collective (they can form a chain).
-      - Fights for dominance among collectives are more complicated.
-        Generally, only two participants should be rolling against each
-        other at any given time. Minds who can co-exist peacefully can
-        nominate the strongest among them to represent their interests,
-        and they can even potentially assist one-another. However, being
-        a component of a large collective that is not at peace with
-        itself can be a traumatic experience for all involved, even the
-        “victors” in the fight for dominance.
+### Burried Alive
 
-  - Shield Bash
-    
-      - Requires: 10 Ranks in Blunt Weapons
-      - Effect: you can hurt people with a shield about as well as other
-        people can with a weapon. You can use your shield as a weapon,
-        using your Blunt Weapons skill and doing 1d10+2+DB DV (AP -).
+The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
+This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through).
 
-  - Sneak Attack
-    
-      - Requires: 10 ranks in an Attack skill.
-      - Effect: You are particularly good at striking weak spots. When
-        you attack an unaware or helpless target, you inflict an
-        additional 1d10 DV.
+- **Requires:** A burrow speed, 20 ranks in Unarmed Combat
+- **Action:** Standard Action (Maneuver)
+- **Effect:** Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.
+If you succeed, you haul your target into your tunnel and partially collapse it.
+This immobilizes them.
+- **Special:** You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power.
+- **Special:** Instead of immobilizing your opponent, you can instead attempt to completely burry them.
+This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate.
 
-  - Blur
-    
-      - Requires: 10 Ranks in Spellcraft, 10 Ranks in Stealth
-    
-      - Action: Sustained
-    
-      - Effect: You become translucent, making you hard to spot.
-        
-          - You gain +10 bonus to Stealth checks to avoid being seen.
+### Center
 
-      - Special: The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it.
+Slow down.  Take a breath, in and then out.  Forget your cause, forget your opponent.  Feel the wapon, move with it, *strike*.
+You have developed a kind of battle-trance, in which your combat instincts are heightened.
 
-  - Vanish
-    
-      - Requires: Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth
-    
-      - Effect: Your Blur improves; you become so difficult to spot that
-        others may fail to notice you even if you are standing in plain
-        sight.
-        
-          - You gain (another) +10 bonus to Stealth checks to avoid
-            being seen.
-          - You may use Stealth to avoid being seen even if you do not
-            have anything to hide behind. Such a Stealth check suffers a
-            -20 modifier.
+- **Requires:** 10 Ranks in Control, 10 ranks in a combat skill.
+- **Action:** Sustained.
+- **Effect:** Your Trance Bonus is your equal to your ranks in Control ÷ 10.
+You gain your Trance Bonus to your INIT.
+- **Special:** No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur.
 
-      - Special: Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft.
+### Centered Defence
 
-  - Charm
-    
-      - Requires: 10 Ranks in Persuasion, 10 Ranks in Spellcraft
-    
-      - Action: Task Action (5 Minutes)
-    
-      - Effect: Conversation with you is enchanting, in a very literal
-        sense.
-        
-          - As you spend time in conversation with someone, you can
-            exert a magical influence over them.
-          - Make an opposed test, your Persuasion versus their Resist
-            Social Manipulation (SAV + INT). If you succeed, they will
-            regard you as a friend, and will view your words and actions
-            in the best possible light.
-          - This does not grant you magical control of their actions, it
-            simply implies that they will trust you and regard you
-            favorably.
+While centered, your defence is improved.
 
-  - Push
-    
-      - Requires: Charm, 20 Ranks in Spellcraft
-    
-      - Effect: you have the ability to “push” your will onto other
-        people.
-        
-          - When you Charm someone, you may attempt a Persuasion check,
-            opposed by their Resist Social Manipulation. If you win,
-            then you may give them a single instruction, which they will
-            carry out to the best of their ability.
-    
-      - Not sure about this one, did it quick. Wanted to avoid this with
-        the base Charm; mind control can get obscene.
+- **Requires:** the *Center* power, 20 ranks in Control, 10 ranks in Fray
+- **Effect:** While sustaining *Center*, you gain +10 to your defence.
 
-  - ~~Weave~~:
-    
-      - Requires: 10 Ranks in Athletics, 10 Ranks in Fray
-    
-      - Action: Standard Action
-    
-      - Effect: You are particularly good at evasive movement.
-        
-          - In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
-          - You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
-          - You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
+### Centered Strike
 
-      - This power is unnecessary now that we added evasive movement back.
+While centered, you strike with extra force.
 
-  - Quick Counter:
-    
-      - Requires: 10 Ranks in Unarmed Combat dunno about that
-    
-      - Action: Quick Action
-    
-      - Effect: You are very good at countering your opponents attacks
-        with a nasty joint lock.
-        
-          - Until the beginning of your next turn, if you are attacked
-            in melee, defend with your Unarmed Skill, win the opposed
-            check (that is, successfully defend against an attack), and
-            score an Exceptional Success, then you automatically grapple
-            the person who attacked you.
+- **Requires:** the *Center* power, 20 ranks in Control
+- **Effect:** While sustaining Center, You gain +Trance Bonus to your DV.
 
-  - Quick Break:
-    
-      - Requires: Quick Counter, 20 Ranks in Unarmed Combat
-    
-      - Effect: when you counter an opponent, you may instead choose to
-        break a joint.
-        
-          - When you Quick Counter an opponent, instead of grappling
-            them, you may choose to inflict a single Wound.
+### Charm
 
-  - Blank
-    
-      - Requires: 20 Ranks in Deception
-    
-      - Action: Sustained
-    
-      - Effect: though it requires some concentration, you have an
-        uncanny ability to blank your expression, replacing it with
-        pleasant neutral demeanor.
-        
-          - While sustaining this power, Read checks made against you
-            suffer a -30 penalty.
-          - However, because your neutral expression makes it hard to
-            convey your emotional state — and might be a little unnerving.
-            You suffer a -10 penalty to Persuasion checks.
-          - Having no penalty to Barter is deliberate, the theory being
-            that this kind of behavior is expected while haggling;
-            likewise, no bonus on Deception was offered, because a bonus
-            to one side of a check coupled with a penalty to the other
-            is a little stiff. Thoughts?
-          - This isn’t a supernatural power; it’s just having a really
-            good poker face. Therefore, it’s neither a Sleight, a Spell,
-            a Boon or a Maneuver; it’s basically just a Power.
+- **Requires:** 10 Ranks in Persuasion, 10 Ranks in Spellcraft
+- **Action:** Task Action (5 Minutes)
+- **Effect:** Conversation with you is enchanting, in a very literal sense.
+  - As you spend time in conversation with someone, you can exert a magical influence over them.
+  - Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
+  - This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably.
 
-  - Conjure
-    
-      - Requires: 10 Ranks in Spellcraft
-    
-      - Action: Sustained
-    
-      - Effect: you can form magic into physical forms, which can mimic
-        simple objects.
-        
-          - While you sustain this power, you can create either three
-            items with cost category Minor, or one object with cost
-            category Medium.
-          - You choose the objects when you first use the Power.
-          - The objects cannot have complex clockwork, cannot be
-            alchemical or otherwise magic, and cannot sustain chemical
-            reactions; you can form cups, knives, jugs, bags, and
-            blades, for example; but you cannot summon potions,
-            explosives, clocks, food or living creatures.
-          - The objects you form are partially translucent, and glow
-            with a ghostly energy; though you can control their
-            appearance up to a point, they are obviously magical
-            creations.
-          - The objects works just like their mundane versions; they
-            don’t hover or act on their own, for example.
+### Collective
 
-  - Eidolon:
-    
-      - Requires: Conjure, 10 Ranks in Control, 20 Ranks in Spellcraft
-    
-      - Action: Sustained
-    
-      - Effect: you can form magic into the shape of a living creature,
-        and you can fracture your mind so that you can control them.
-        
-          - You get one creature, hereafter called an Eidolon.
-          - Each Eidolon is Small, has 15 DUR and 20 STR, has a movement
-            of Walking 3/9, has Normal Senses, and has the Spirit,
-            Humanoid and Eidolon tags. As magical apparitions, they
-            don’t need to eat, drink, breath or sleep.
-          - The Eidolon does not have a mind of its own; rather, you
-            control its actions, as if it was an extension of your body.
-            This means that it uses your Aptitudes and Skill Ranks;
-            appropriate powers, classes and traits may also be used
-            through your Eidolon, at the GM’s discretion.
-          - Mechanically, the you can use your actions to either act
-            through your Character, or to have your Eidolon act. So, for
-            example, during your turn you could use a Quick Action to
-            have your character move, and a Standard Action to attack
-            with your Eidolon.
-          - You may choose three bonuses for the Eidolon from the
-            Bonuses list.
-    
-      - Bonuses:
-        
-          - Carapace: the Eidolon has a sturdy shell, thick hide, or is
-            otherwise reinforced; it gains 4 Armor.
-        
-          - Claws: the Eidolon gains claws:
-            
-              - Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural
-                Weapon, Off-Hand.
-        
-          - Form: the Eidolon gains the appearance of an animal; it
-            appears to be a normal creature of the given type. (Its
-            stats don’t change, and it is immediately obvious to anyone
-            with Mage Sight that it is a magical conjuration.)
-        
-          - Regen: the Eidolon has Fast Healing 2.
-        
-          - Sense: the Eidolon gains the benefit of one of your Senses.
-            (e.g. if you have Magesight, then you may give the Eidolon
-            Mage Sight.)
-        
-          - Size: the Eidolon is Size Medium.
-        
-          - Sturdy: the Eidolon has +10 DUR and +5 STR.
-        
-          - Wings: the Eidolon has wings; it gains the following
-            movement mode: Fly (5/15)
-      
-      - Unique Drawbacks:
-      
-          - Some races have unique drawbacks — for example, the fact that Clay Men are *blind*.
-            These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
-            Because of this, GM's have the option of declaring a certain feature of a character to be a "major drawback"; they can then require that that character's Eidolon exibit that drawback.
-            For example, a GM could declare that a Clay Man's *blind* trait is a "major drawback," and thus their eidolon is *also* blind.
-          - We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
-            Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see.
+- **Requires:** Join, Link, 30 Ranks in Control
+- **Effect:** 
+  - You can incorporate more than one mind into the Gestalt created by Join. To add a new mind, you must use Join on that mind, and you must then Link that mind.
+  - To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
+  - Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
+and they can even potentially assist one-another. However, being a component of a large collective that is not at peace with itself can be a traumatic experience for all involved, even the “victors” in the fight for dominance.
+- **Special:** To use this power, you must be sustaining Join, and you must have linked with the target.
 
-  - Enhanced Eidolon
-    
-      - Requires: Eidolon, 20 Ranks in Spellcraft
-    
-      - Effect: you have more Bonuses available. You can select from the
-        following list, as well as the Bonus list above:
-        
-          - Ethereal: the Eidolon can become intangible for short
-            periods of time. It gains the following Power:
-            
-              - Action: Quick Action
-              - Effect: the Eidolon becomes intangible. Until its next
-                turn, it can pass straight through solid objects, and
-                solid objects will pass through it. This means it cannot
-                be damaged by weapons, but it also means that it cannot
-                (practically) attack other Creatures, or interact with
-                objects.
-        
-          - Fire: a fire simmers within the Eidolon, and it can flare
-            forth. The fire provides illumination like a torch. The
-            Eidolon also gains the following Power:
-            
-              - Action: Sustained
-              - Effect: the Eidolon flares forth, becoming a creature of
-                flame. Anything in contact with it suffers 1D10 damage.
-                Its natural attacks gain the Fire tag, and cause an
-                additional 1D10 DV.
-        
-          - Frost: the Eidolon is suffused with frost, appearing to be
-            made from chipped ice. The Eidolon gains +2 Armor and +5
-            DUR, and it gains the following Power:
-            
-              - Action: Standard
-              - Effect: the Eidolon can freeze something that it
-                touches. Treat this as a Touch-Only Attack. If it hits,
-                the target suffers 1D10 DV.
-        
-          - Spines: the Eidolon can launch spines, giving it a potent
-            ranged attack. It gains the following attack:
-            
-              - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags:
-                Natural Weapon. Range: 20m/30m/40m
+### Conjure
 
-  - Eidolons:
-    
-      - Requires: Eidolon
-      - Effect: When you activate the Eidolon power, you can create a
-        second Eidolon; if you do, each Eidolon only gets two Bonuses.
+- **Requires:** 10 Ranks in Spellcraft
+- **Action:** Sustained
+- **Effect:** You can form magic into physical forms, which can mimic simple objects.
+  - While you sustain this power, you can create either three items with cost category Minor, or one object with cost category Medium.
+  - You choose the objects when you first use the Power.
+  - The objects cannot have complex clockwork, cannot be alchemical or otherwise magic, and cannot sustain chemical reactions; you can form cups, knives, jugs, bags, and blades, for example; but you cannot summon potions, explosives, clocks, food or living creatures.
+  - The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
+  - The objects works just like their mundane versions; they don’t hover or act on their own, for example.
 
-  - Imbue:
-    
-      - Requires: Eidolon, 20 ranks in Control
-    
-      - Effect: you can fracture your mind, producing a copy of your
-        consciousness for each Eidolon that you have.
-        
-          - While sustaining Eidolon, each Eidolon gets its own turn.
-            They act on your initiative, after your turn.
-          - It’s still your mind controlling them, so you control them,
-            and you’re aware of what they see and do.
+### Denial
 
-  - Protection
-    
-      - Requires: *Attendant of the Mourner* Class
-      - Action: Sustained
-      - Effect: You gain +3 armor, and those you choose within 5m of you
-        gain +2 armor.
+While in your battle-trance, your defence is nearly perfect.
 
-#### Rallying Cry
+- **Requires:** the *Centered Defence* power, 20 ranks in Fray
+- **Effect:** If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)
+
+### Diving Strike
+
+You've perfected a diving strike, using the momentum of your fall to strengthen your attack.
+
+- **Requires:** 10 ranks in Athletics, 10 ranks in a *melee combat* skill.
+- **Action:** Quick Action (Movement)
+- **Effect:** When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)
+
+### Down-Time
+
+You can enter a deep, meditative state, in which you can nourish, refresh and repair both your mind and body.
+
+- **Requires:** Transcend, 20 Control
+- **Action:** 4-Hour Task Action
+- **Effect:** 
+  - After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
+  - After completing the Sleight, you recover 1d10÷3 Stress.
+  - While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day.
+- **Special:** If you have the Heal Sleight, you may also sustain it during Down Time.
+
+### Eidolon
+
+- **Requires:** Conjure, 10 Ranks in Control, 20 Ranks in Spellcraft
+- **Action:** Sustained
+- **Effect:** You can form magic into the shape of a living creature, and you can fracture your mind so that you can control them.
+  - You get one creature, hereafter called an Eidolon.
+  - Each Eidolon is Small, has 15 DUR and 20 STR, has a movement of Walking 3/9, has Normal Senses, and has the Spirit, Humanoid and Eidolon tags.  As magical apparitions, they don’t need to eat, drink, breath or sleep.
+  - The Eidolon does not have a mind of its own; rather, you control its actions, as if it was an extension of your body.  This means that it uses your Aptitudes and Skill Ranks; appropriate powers, classes and traits may also be used through your Eidolon, at the GM’s discretion.
+  - Mechanically, the you can use your actions to either act through your Character, or to have your Eidolon act.  So, for example, during your turn you could use a Quick Action to have your character move, and a Standard Action to attack with your Eidolon.
+  - You may choose three bonuses for the Eidolon from the Bonuses list.
+- **Bonuses:** 
+  - Carapace: the Eidolon has a sturdy shell, thick hide, or is otherwise reinforced; it gains 4 Armor.
+  - Claws: the Eidolon gains claws:
+    - Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural Weapon, Off-Hand.
+  - Form: the Eidolon gains the appearance of an animal; it appears to be a normal creature of the given type. (Its stats don’t change, and it is immediately obvious to anyone with Mage Sight that it is a magical conjuration.)
+  - Regen: the Eidolon has Fast Healing 2.
+  - Sense: the Eidolon gains the benefit of one of your Senses.  (e.g. if you have Magesight, then you may give the Eidolon Mage Sight.)
+  - Size: the Eidolon is Size Medium.
+  - Sturdy: the Eidolon has +10 DUR and +5 STR.
+  - Wings: the Eidolon has wings; it gains the following movement mode: Fly (5/15)
+- **Special:** Some races have unique drawbacks — for example, the fact that Clay Men are *blind*.
+  - These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
+Because of this, GM's have the option of declaring a certain feature of a character to be a "major drawback"; they can then require that that character's Eidolon exibit that drawback.
+For example, a GM could declare that a Clay Man's *blind* trait is a "major drawback," and thus their eidolon is *also* blind.
+  - We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
+Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see.
+
+### Eidolons
+
+- **Requires:** Eidolon
+- **Effect:** When you activate the Eidolon power, you can create a second Eidolon; if you do, each Eidolon only gets two Bonuses.
+
+### Enhanced Eidolon
+
+- **Requires:** Eidolon, 20 Ranks in Spellcraft
+- **Effect:** you have more Bonuses available. You can select from the following list, as well as the Bonus list above:
+  - Ethereal: the Eidolon can become intangible for short periods of time. It gains the following Power:
+    - Action: Quick Action
+    - Effect: the Eidolon becomes intangible. Until its next turn, it can pass straight through solid objects, and solid objects will pass through it. This means it cannot be damaged by weapons, but it also means that it cannot (practically) attack other Creatures, or interact with objects.
+  - Fire: a fire simmers within the Eidolon, and it can flare forth. The fire provides illumination like a torch. The Eidolon also gains the following Power:
+    - Action: Sustained
+    - Effect: the Eidolon flares forth, becoming a creature of flame. Anything in contact with it suffers 1D10 damage.  Its natural attacks gain the Fire tag, and cause an additional 1D10 DV.
+  - Frost: the Eidolon is suffused with frost, appearing to be made from chipped ice. The Eidolon gains +2 Armor and +5 DUR, and it gains the following Power:
+  -   Action: Standard
+    - Effect: the Eidolon can freeze something that it touches. Treat this as a Touch-Only Attack. If it hits, the target suffers 1D10 DV.
+  - Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
+    - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m
+
+### Exploding Fireball
+
+- **Requires:** Fireball and 20 ranks in Spellcraft
+- **Effect:** When using the Fireball power, when your fireball expires (either because you dismissed it or because it left contact with you), you may choose to have it explode. Treat this as a Blast effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)
+
+### Fireball
+
+You can manifest a fireball in your hand.
+
+- **Requires:** 10 ranks in Spellcraft
+- **Action:** Quick Action
+- **Effect:** You manifest a ball of fire in your hand.
+  - After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
+  - If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
+  - You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
+  - The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
+  - Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag).
+
+### Fortify
+
+- **Requires:** 20 ranks in Control
+- **Action:** Sustained
+- **Effect:** You can fortify your physical and mental abilities.
+  - While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
+  - (Your derived stats would also change, as normal.)
+
+### Group Jump
+
+- **Requires:** Jump, 20 ranks in Spellcraft
+- **Effect:** when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft.
+
+### Heal
+
+- **Requires:** 10 Control
+- **Action:** Sustained
+- **Effect:** Your wounds begin to heal.
+  - While sustaining this power, you have Fast Healing 1.
+  - While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2.
+- **Special:** If you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check.
+
+### Hurl an Ally
+
+You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands.
+
+- **Requires:** The *Missile-Hurler* class.
+- **Action:** Standard Action
+- **Effect:** You can throw an ally.
+  - They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
+  - If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
+  - If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
+  - If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
+  - They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn.
+- **Special:** This power represents *throwing* an ally, which is a Standard Action.
+Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action).
+- **Special:** If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*
+
+### Imbue
+
+- **Requires:** Eidolon, 20 ranks in Control
+- **Effect:** You can fracture your mind, producing a copy of your consciousness for each Eidolon that you have.
+  - While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
+  - It’s still your mind controlling them, so you control them, and you’re aware of what they see and do.
+
+### Intense Fire
+
+- **Requires:** 20 ranks in Spellcraft
+- **Effect:** Your fire spells do an additional 1d10 DV of damage and have AP -1.
+
+### Join
+
+- **Requires:** 10 Ranks in Control
+- **Action:** Sustained
+- **Effect:** You join minds with the target, creating a Gestalt. Normally, this is an equal blending; however, under some circumstances – particularly if the target is unwilling – the two minds might fight for dominance over the Gestalt. Treat this as an opposed WIL&times;3 check, with the winner gaining dominance, and thereafter being able to direct the actions of the gestalt.
+  - The gestalt mind has access to the skills, knowledge and memories of both individuals. The gestalt mind will also express the desires of both minds – even if one mind has become dominant, the other mind in the Gestalt cannot be suppressed completely.
+  - Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
+  - Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
+  - For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have.
+- **Special:** To use this Power, you must be touching one character; this character is the target of the Power.
+If you loose physical contact with the target, the power ends.
+
+### Journey
+
+- **Requires:** Long Jump, 30 ranks in Spellcraft
+- **Action:** Task Action (1 minute)
+- **Effect:** You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft.
+
+### Jump
+
+- **Requires:** 10 ranks in Spellcraft
+- **Action:** Quick Action
+- **Effect:** You teleport, moving up to twice your Running movement.
+
+### Link
+
+- **Requires:** Join, 20 Ranks in Control
+- **Action:** Task Action (5 minutes)
+- **Effect:** You link your mind with the target's.
+  - While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
+  - The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends.
+- **Special:** To use this power, you must be sustaining Join.
+
+### Long Jump
+
+- **Requires:** Jump, 20 ranks in Spellcraft
+- **Action:** Standard Action
+- **Effect:** You teleport, moving up to 10 times your Running movement.
+
+### Master
+
+- **Requires:** 10 ranks in Control
+- **Action:** Sustained
+- **Effect:** You can use your own intrinsic magic to control (and fortify) your own life processes.
+  - While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
+  - While sustaining this power, you gain +1 Armor.
+
+### Pilot
+
+- **Requires:** Journey, Group Jump
+- **Action:** Task Action (10 minutes)
+- **Effect:** You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network.
+
+### Protection
+
+- **Requires:** *Attendant of the Mourner* Class
+- **Action:** Sustained
+- **Effect:** You gain +3 armor, and those you choose within 5m of you gain +2 armor.
+
+### Push
+
+- **Requires:** Charm, 20 Ranks in Spellcraft
+- **Effect:** You have the ability to “push” your will onto other people.
+  - When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability.
+
+### Quick Break
+
+- **Requires:** Quick Counter, 20 Ranks in Unarmed Combat
+- **Effect:** When you counter an opponent, you may instead choose to break a joint.
+  - When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound.
+
+### Quick Counter
+
+- **Requires:** 10 Ranks in Unarmed Combat dunno about that
+- **Action:** Quick Action
+- **Effect:** You are very good at countering your opponents attacks with a nasty joint lock.
+  - Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you.
+
+### Rallying Cry
 
 You can inspire others to bravery and heroism even in the direst of circumstances.
 
@@ -582,15 +427,7 @@ You can inspire others to bravery and heroism even in the direst of circumstance
   - Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all.
 - **Special:** The GM may allow you to inspire those around you if you do something particularly heroic: it might be inspiring just to see you burst out of bonds or rise again in spite of grievous wounds.
 
-#### Diving Strike
-
-You've perfected a diving strike, using the momentum of your fall to strengthen your attack.
-
-- **Requires:** 10 ranks in Athletics, 10 ranks in a *melee combat* skill.
-- **Action:** Quick Action (Movement)
-- **Effect:** When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)
-
-#### Reckless Dive
+### Reckless Dive
 
 Through some mix of talent, luck, bravery and foolishness, you can drop on targets from great heights, and usually hurt them a lot worse than you hurt yourself.
 
@@ -598,7 +435,13 @@ Through some mix of talent, luck, bravery and foolishness, you can drop on targe
 - **Effect:** When you make a Diving Strike, any fall damage that you take is also added to your attack's damage.  (You still take the given fall damage.)
   - For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage.
 
-#### Rough Landing
+### Regrowth
+
+- **Requires:** Heal, 20 Control
+- **Action:** Task Action (1 Hour)
+- **Effect:** Roll a Control check. If you succeed, you heal one wound.
+
+### Rough Landing
 
 Luckily, your opponent broke your fall!
 
@@ -606,107 +449,59 @@ Luckily, your opponent broke your fall!
 - **Effect:** When you use your Reckless Dive power, you may reduce the damage that you take by 1d10; your opponent still takes the full falling damage.
   - For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage).
 
-#### Acrobatic Strike
+### Sacrifice
 
-By kicking off walls, flipping over obstacles or otherwise acrobatically exploiting your environment, you can build up a lot of momentum in a short space.
+- **Requires:** Transfer, 20 Control
+- **Action:** Task Action (1 minute)
+- **Effect:** You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound. (Note: the wound is not *bound*, it is entirely healed.)
+  - Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted.
+- **Special:** To use this power, you must be sustaining Transfer.
 
-- **Requires** 20 ranks in Athletics, 10 ranks in a *melee combat* skill.
-- **Action** Varies (stunt, movement)
-- **Effect:** When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
-  - An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle.
+### Shield Bash
 
-#### Center
+- **Requires:** 10 Ranks in Blunt Weapons
+- **Effect:** You can hurt people with a shield about as well as other people can with a weapon.
+You can use your shield as a weapon, using your Blunt Weapons skill and doing 1d10+2+DB DV (AP -).
 
-Slow down.  Take a breath, in and then out.  Forget your cause, forget your opponent.  Feel the wapon, move with it, *strike*.
-
-You have developed a kind of battle-trance, in which your combat instincts are heightened.
-
-- **Requires:** 10 Ranks in Control, 10 ranks in a combat skill.
-- **Action:** Sustained.
-- **Effect:** Your Trance Bonus is your equal to your ranks in Control ÷ 10.  You gain your Trance Bonus to your INIT.
-- **Special:** No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur.
-
-#### Centered Strike
-
-While centered, you strike with extra force.
-
-- **Requirements:** the *Center* power, 20 ranks in Control
-- **Effect:** While sustaining Center, You gain +Trance Bonus to your DV.
-
-#### Centered Defence
-
-While centered, your defense is improved.
-
-- **Requirements:** the *Center* power, 20 ranks in Control, 10 ranks in Fray
-- **Effect:** While sustaining *Center*, you gain +10 to your defence.
-
-#### Denial
-
-While in your battle-trance, your defence is nearly perfect.
-
-- **Requirements:** the *Centered Defence* power, 20 ranks in Fray
-- **Effect:** If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)
-
-#### Shieldwall
+### Shieldwall
 
 You are expert in the use of large shields, and your defence with them is extraordinary.
 
-- **Requirements:** 20 ranks in Fray
+- **Requires:** 20 ranks in Fray
 - **Effect:** If you are using a Heater Shield, Tower Shield or similar large shield, then, while using a Full Defense action, you are considered to be in cover from direction of your shield.  (This means that you cannot be directly attacked from that side.)
   - Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
   - While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)
 
+### Sneak Attack
 
-#### Brawler's Instinct
+- **Requires:** 10 ranks in an Attack skill.
+- **Effect:** You are particularly good at striking weak spots.
+When you attack an unaware or helpless target, you inflict an additional 1d10 DV.
 
-Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight.
+### Transfer
 
-- **Requirement:** 10 ranks in Perception, 10 ranks in two *combat* skills.
-- **Effect:** You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you.
-
-#### Brawler's Sense
-
-Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has...
-
-- **Requirements:** 20 ranks in Perception, 20 ranks in Unarmed Combat
+- **Requires:** 10 Control
 - **Action:** Sustained
-- **Effect:** While sustaining this power, you gain *Brawler's Sense* as a sense.
-  - This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
-  - This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
-  - What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty.
+- **Effect:** You transfer wounds from a creature that you touch to yourself.
+  - For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
+  - This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons.
+- **Special:** To use this power, you must be touching one other creature, and that creature must have a DUR rating.
 
-#### Bound Fighter
+### Vanish
 
-Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up.
+- **Requires:** Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth
+- **Effect:** Your Blur improves; you become so difficult to spot that others may fail to notice you even if you are standing in plain sight.
+  - You gain (another) +10 bonus to Stealth checks to avoid being seen.
+  - You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier.
+- **Special:** Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft.
 
-- **Requirements:** 20 ranks in Unarmed Combat
+### Weave
+
+- **Requires:** 10 Ranks in Athletics, 10 Ranks in Fray
 - **Action:** Standard Action
-- **Effect:** When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack.
-- **Special:** You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden.
-- **Special:** Critical hits with this attack may weaken or break weaker bindings, like ropes.
+- **Effect:** You are particularly good at evasive movement.
+  - In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
+  - You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
+  - You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
+  - This power is unnecessary now that we added evasive movement back.
 
-#### Burried Alive
-
-The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
-This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through).
-
-- **Requirements:** A burrow speed, 20 ranks in Unarmed Combat
-- **Action:** Standard Action (Maneuver)
-- **Effect:** Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.  If you succeed, you haul your target into your tunnel and partially collapse it.  This immobilizes them.
-- **Special:** You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power.
-- **Special:** Instead of immobilizing your opponent, you can instead attempt to completely burry them.  This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate.
-
-#### Hurl an Ally
-
-You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands.
-
-- **Requirements:** The *Missile-Hurler* class.
-- **Action:** Standard Action
-- **Effect:** You can throw an ally.
-  - They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
-  - If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
-  - If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
-  - If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
-    - They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn.
-- **Special:** This power represents *throwing* an ally, which is a Standard Action.  Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action).
-- **Special:** If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*

--- a/src/datafiles/gen_powers_page.py
+++ b/src/datafiles/gen_powers_page.py
@@ -1,0 +1,34 @@
+import sys
+import toml
+
+with open("powers.toml", "r") as ifile:
+    parsed = toml.loads(ifile.read())
+
+# print(parsed)
+
+standard_keys = ['General', 'Name', 'Fluff', 'Requires', 'Action', 'Effect', 'Sections']
+
+for power in sorted(parsed["Powers"], key=lambda x: x['Name']):
+    if 'General' not in power or power['General'] == False:
+        continue
+
+    sys.stdout.write(f"### {power['Name']}\n\n")
+
+    if "Fluff" in power:
+        sys.stdout.write(f"{power['Fluff']}\n\n")
+
+    if "Requires" in power:
+        sys.stdout.write(f"- **Requires**: {power['Requires']}\n")
+    if "Action" in power:
+        sys.stdout.write(f"- **Action**: {power['Action']}\n")
+    sys.stdout.write(f"- **Effect**: {power['Effect']}\n")
+    if 'Sections' in power:
+        for section in power['Sections']:
+            sys.stdout.write(f"- {section['Label']}: {section['Content']}\n")
+
+    sys.stdout.write("\n")
+
+    for key in power.keys():
+        if key not in standard_keys:
+            sys.stderr.write(f"Power {power['Name']} contianed non-standard key {key}\n")
+

--- a/src/datafiles/gen_powers_page.py
+++ b/src/datafiles/gen_powers_page.py
@@ -18,13 +18,13 @@ for power in sorted(parsed["Powers"], key=lambda x: x['Name']):
         sys.stdout.write(f"{power['Fluff']}\n\n")
 
     if "Requires" in power:
-        sys.stdout.write(f"- **Requires**: {power['Requires']}\n")
+        sys.stdout.write(f"- **Requires:** {power['Requires']}\n")
     if "Action" in power:
-        sys.stdout.write(f"- **Action**: {power['Action']}\n")
-    sys.stdout.write(f"- **Effect**: {power['Effect']}\n")
+        sys.stdout.write(f"- **Action:** {power['Action']}\n")
+    sys.stdout.write(f"- **Effect:** {power['Effect']}\n")
     if 'Sections' in power:
         for section in power['Sections']:
-            sys.stdout.write(f"- {section['Label']}: {section['Content']}\n")
+            sys.stdout.write(f"- **{section['Label']}:** {section['Content']}\n")
 
     sys.stdout.write("\n")
 

--- a/src/datafiles/gen_powers_page.py
+++ b/src/datafiles/gen_powers_page.py
@@ -6,29 +6,29 @@ with open("powers.toml", "r") as ifile:
 
 # print(parsed)
 
-standard_keys = ['General', 'Name', 'Fluff', 'Requires', 'Action', 'Effect', 'Sections']
+standard_keys = ['general', 'name', 'fluff', 'requires', 'action', 'effect', 'sections']
 
-for power in sorted(parsed["Powers"], key=lambda x: x['Name']):
-    if 'General' not in power or power['General'] == False:
+for power in sorted(parsed["powers"], key=lambda x: x['name']):
+    if 'general' not in power or power['general'] == False:
         continue
 
-    sys.stdout.write(f"### {power['Name']}\n\n")
+    sys.stdout.write(f"### {power['name']}\n\n")
 
-    if "Fluff" in power:
-        sys.stdout.write(f"{power['Fluff']}\n\n")
+    if "fluff" in power:
+        sys.stdout.write(f"{power['fluff']}\n\n")
 
-    if "Requires" in power:
-        sys.stdout.write(f"- **Requires:** {power['Requires']}\n")
-    if "Action" in power:
-        sys.stdout.write(f"- **Action:** {power['Action']}\n")
-    sys.stdout.write(f"- **Effect:** {power['Effect']}\n")
-    if 'Sections' in power:
-        for section in power['Sections']:
-            sys.stdout.write(f"- **{section['Label']}:** {section['Content']}\n")
+    if "requires" in power:
+        sys.stdout.write(f"- **Requires:** {power['requires']}\n")
+    if "action" in power:
+        sys.stdout.write(f"- **Action:** {power['action']}\n")
+    sys.stdout.write(f"- **Effect:** {power['effect']}\n")
+    if 'sections' in power:
+        for section in power['sections']:
+            sys.stdout.write(f"- **{section['label']}:** {section['content']}\n")
 
     sys.stdout.write("\n")
 
     for key in power.keys():
         if key not in standard_keys:
-            sys.stderr.write(f"Power {power['Name']} contianed non-standard key {key}\n")
+            sys.stderr.write(f"Power {power['name']} contianed non-standard key {key}\n")
 

--- a/src/datafiles/notes.md
+++ b/src/datafiles/notes.md
@@ -1,0 +1,15 @@
+```
+sed 's/^- \*\*\(\w\+\)\:\*\*/- \1:/' < powers.mostlymd.dat | sed 's/^- \(\w\+\)\:/\%\1\%\n/' > powers.dat
+```
+
+God *damn* it, Alexis.
+
+```
+sed 's/\[\(.*\)\]/[[Powers]]\nname = "\1"/' < powers.orig.toml | sed 's/Special = /[[Powers.Section]]\nLabel = Special\nContent = /' | sed 's/Effect = /[[Powers.Section]]\nLabel = "Effect"\nContent = /' > powers.toml 
+```
+
+This *thing* from [this so](https://stackoverflow.com/questions/9999934/sed-joining-lines-depending-on-the-second-one), which helped merge the """ lines.
+
+```
+sed 'N;s/\n"""/"""/;P;D' < powers.bad.toml > powers.toml
+```

--- a/src/datafiles/powers.dat
+++ b/src/datafiles/powers.dat
@@ -1,4 +1,6 @@
-# Fireball
+# A list of powers.
+
+[Fireball]
 %Fluff%
 You can manifest a fireball in your hand.
 %Requires%
@@ -13,58 +15,66 @@ You manifest a ball of fire in your hand.
 - You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
 - The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
 - Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag).
+//
 
-# Exploding Fireball
+[Exploding Fireball]
 %Requires%
 Fireball and 20 ranks in Spellcraft
 %Effect%
 When using the Fireball power, when your fireball expires (either because you dismissed it or because it left contact with you), you may choose to have it explode. Treat this as a Blast effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)
+//
 
-# Intense Fire
+[Intense Fire]
 %Requires%
 20 ranks in Spellcraft
 %Effect%
 Your fire spells do an additional 1d10 DV of damage and have AP -1.
+//
 
-# Jump
+[Jump]
 %Requires%
 10 ranks in Spellcraft
 %Action%
 Quick Action
 %Effect%
 You teleport, moving up to twice your Running movement.
+//
 
-# Group Jump
+[Group Jump]
 %Requires%
 Jump, 20 ranks in Spellcraft
 %Effect%
 when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft.
+//
 
-# Long Jump
+[Long Jump]
 %Requires%
 Jump, 20 ranks in Spellcraft
 %Action%
 Standard Action
 %Effect%
 You teleport, moving up to 10 times your Running movement.
+//
 
-# Journey
+[Journey]
 %Requires%
 Long Jump, 30 ranks in Spellcraft
 %Action%
 Task Action (1 minute)
 %Effect%
 You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft.
+//
 
-# Pilot
+[Pilot]
 %Requires%
 Journey, Group Jump
 %Action%
 Task Action (10 minutes)
 %Effect%
 You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network.
+//
 
-# Master
+[Master]
 %Requires%
 10 Control
 %Action%
@@ -74,8 +84,9 @@ You can use your own intrinsic magic to control (and fortify) your own life proc
 
 - While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
 - While sustaining this power, you gain +1 Armor.
+//
 
-# Down-Time
+[Down-Time]
 %Fluff%
 You can enter a deep, meditative state, in which you can nourish, refresh and repair both your mind and body.
 %Requires%
@@ -87,8 +98,9 @@ Transcend, 20 Control
 - After completing the Sleight, you recover 1d10÷3 Stress.
 - While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day.
 - Special: if you have the Heal Sleight, you may also sustain it during Down Time.
+//
 
-# Fortify
+[Fortify]
 %Requires%
 20 Control
 %Action%
@@ -98,8 +110,9 @@ You can fortify your physical and mental abilities.
 
 - While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
 - (Your derived stats would also change, as normal.)
+//
 
-# Heal
+[Heal]
 %Requires%
 10 Control
 %Action%
@@ -110,8 +123,9 @@ Your wounds begin to heal.
 - While sustaining this power, you have Fast Healing 1.
 - While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2.
 - Special: if you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check.
+//
 
-# Transfer
+[Transfer]
 %Requires%
 10 Control
 %Action%
@@ -123,16 +137,18 @@ You transfer wounds from a creature that you touch to yourself.
 
 - For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
 - This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons.
+//
 
-# Regrowth
+[Regrowth]
 %Requires%
 Heal, 20 Control
 %Action%
 Task Action (1 Hour)
 %Effect%
 Roll a Control check. If you succeed, you heal one wound.
+//
 
-# Sacrifice
+[Sacrifice]
 %Requires%
 Transfer, 20 Control
 %Action%
@@ -143,8 +159,9 @@ To use this power, you must be sustaining Transfer
 You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound. (Note: the wound is not *bound*, it is entirely healed.)
 
 - Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted.
+//
 
-# Join
+[Join]
 %Requires%
 10 Ranks in Control
 %Action%
@@ -158,8 +175,9 @@ You join minds with the target, creating a Gestalt. Normally, this is an equal b
 - Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
 - Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
 - For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have.
+//
 
-# Link
+[Link]
 %Requires%
 Join, 20 Ranks in Control
 %Action%
@@ -169,8 +187,9 @@ To use this power, you must be sustaining Join.
 
 - While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
 - The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends.
+//
 
-# Collective
+[Collective]
 %Requires%
 Join, Link, 30 Ranks in Control
 %Condition%
@@ -180,20 +199,23 @@ You must be sustaining Join, and you must have Linked with the target.
 - To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
 - Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
 and they can even potentially assist one-another. However, being a component of a large collective that is not at peace with itself can be a traumatic experience for all involved, even the “victors” in the fight for dominance.
+//
 
-# Shield Bash
+[Shield Bash]
 %Requires%
 10 Ranks in Blunt Weapons
 %Effect%
 you can hurt people with a shield about as well as other people can with a weapon. You can use your shield as a weapon, using your Blunt Weapons skill and doing 1d10+2+DB DV (AP -).
+//
 
-# Sneak Attack
+[Sneak Attack]
 %Requires%
 10 ranks in an Attack skill.
 %Effect%
 You are particularly good at striking weak spots. When you attack an unaware or helpless target, you inflict an additional 1d10 DV.
+//
 
-# Blur
+[Blur]
 %Requires%
 10 Ranks in Spellcraft, 10 Ranks in Stealth
 %Action%
@@ -204,8 +226,9 @@ You become translucent, making you hard to spot.
 - You gain +10 bonus to Stealth checks to avoid being seen.
 %Special%
 The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it.
+//
 
-# Vanish
+[Vanish]
 %Requires%
 Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth
 %Effect%
@@ -215,8 +238,9 @@ Your Blur improves; you become so difficult to spot that others may fail to noti
 - You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier.
 %Special%
 Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft.
+//
 
-# Charm
+[Charm]
 %Requires%
 10 Ranks in Persuasion, 10 Ranks in Spellcraft
 %Action%
@@ -227,16 +251,18 @@ Conversation with you is enchanting, in a very literal sense.
 - As you spend time in conversation with someone, you can exert a magical influence over them.
 - Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
 - This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably.
+//
 
-# Push
+[Push]
 %Requires%
 Charm, 20 Ranks in Spellcraft
 %Effect%
 You have the ability to “push” your will onto other people.
 
 - When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability.
+//
 
-# Weave
+[Weave]
 %Requires%
 10 Ranks in Athletics, 10 Ranks in Fray
 %Action%
@@ -248,8 +274,9 @@ You are particularly good at evasive movement.
 - You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
 - You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
 - This power is unnecessary now that we added evasive movement back.
+//
 
-# Quick Counter
+[Quick Counter]
 %Requires%
 10 Ranks in Unarmed Combat dunno about that
 %Action%
@@ -258,16 +285,18 @@ Quick Action
 You are very good at countering your opponents attacks with a nasty joint lock.
 
 - Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you.
+//
 
-# Quick Break
+[Quick Break]
 %Requires%
 Quick Counter, 20 Ranks in Unarmed Combat
 %Effect%
 When you counter an opponent, you may instead choose to break a joint.
 
 - When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound.
+//
 
-# Blank
+[Blank]
 %Requires%
 20 Ranks in Deception
 %Action%
@@ -277,8 +306,9 @@ Though it requires some concentration, you have an uncanny ability to blank your
 
 - While sustaining this power, Read checks made against you suffer a -30 penalty.
 - However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks.
+//
 
-# Conjure
+[Conjure]
 %Requires%
 10 Ranks in Spellcraft
 %Action%
@@ -291,8 +321,9 @@ You can form magic into physical forms, which can mimic simple objects.
 - The objects cannot have complex clockwork, cannot be alchemical or otherwise magic, and cannot sustain chemical reactions; you can form cups, knives, jugs, bags, and blades, for example; but you cannot summon potions, explosives, clocks, food or living creatures.
 - The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
 - The objects works just like their mundane versions; they don’t hover or act on their own, for example.
+//
 
-# Eidolon
+[Eidolon]
 %Requires%
 Conjure, 10 Ranks in Control, 20 Ranks in Spellcraft
 %Action%
@@ -323,8 +354,9 @@ Because of this, GM's have the option of declaring a certain feature of a charac
 For example, a GM could declare that a Clay Man's *blind* trait is a "major drawback," and thus their eidolon is *also* blind.
 - We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
 Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see.
+//
 
-# Enhanced Eidolon
+[Enhanced Eidolon]
 %Requires%
 Eidolon, 20 Ranks in Spellcraft
 %Effect%
@@ -341,14 +373,16 @@ you have more Bonuses available. You can select from the following list, as well
   - Effect: the Eidolon can freeze something that it touches. Treat this as a Touch-Only Attack. If it hits, the target suffers 1D10 DV.
 - Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
   - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m
+//
 
-# Eidolons
+[Eidolons]
 %Requires%
 Eidolon
 %Effect%
 When you activate the Eidolon power, you can create a second Eidolon; if you do, each Eidolon only gets two Bonuses.
+//
 
-# Imbue
+[Imbue]
 %Requires%
 Eidolon, 20 ranks in Control
 %Effect%
@@ -356,16 +390,18 @@ You can fracture your mind, producing a copy of your consciousness for each Eido
 
 - While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
 - It’s still your mind controlling them, so you control them, and you’re aware of what they see and do.
+//
 
-# Protection
+[Protection]
 %Requires%
 *Attendant of the Mourner* Class
 %Action%
 Sustained
 %Effect%
 You gain +3 armor, and those you choose within 5m of you gain +2 armor.
+//
 
-# Rallying Cry
+[Rallying Cry]
 %Fluff%
 You can inspire others to bravery and heroism even in the direst of circumstances.
 %Requires%
@@ -379,8 +415,9 @@ Roll one of your Social Skills (the GM must approve of your choice).  If you suc
 - Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all.
 %Special%
 The GM may allow you to inspire those around you if you do something particularly heroic: it might be inspiring just to see you burst out of bonds or rise again in spite of grievous wounds.
+//
 
-# Diving Strike
+[Diving Strike]
 %Fluff%
 You've perfected a diving strike, using the momentum of your fall to strengthen your attack.
 %Requires%
@@ -389,8 +426,9 @@ You've perfected a diving strike, using the momentum of your fall to strengthen 
 Quick Action (Movement)
 %Effect%
 When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)
+//
 
-# Reckless Dive
+[Reckless Dive]
 %Fluff%
 Through some mix of talent, luck, bravery and foolishness, you can drop on targets from great heights, and usually hurt them a lot worse than you hurt yourself.
 %Requires%
@@ -399,8 +437,9 @@ the *Diving Strike* power, 20 ranks in Athletics
 When you make a Diving Strike, any fall damage that you take is also added to your attack's damage.  (You still take the given fall damage.)
 
 - For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage.
+//
 
-# Rough Landing
+[Rough Landing]
 %Fluff%
 Luckily, your opponent broke your fall!
 %Requires%
@@ -409,8 +448,9 @@ the *Reckless Dive* power, 20 ranks in Athletics
 When you use your Reckless Dive power, you may reduce the damage that you take by 1d10; your opponent still takes the full falling damage.
 
 - For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage).
+//
 
-# Acrobatic Strike
+[Acrobatic Strike]
 %Fluff%
 By kicking off walls, flipping over obstacles or otherwise acrobatically exploiting your environment, you can build up a lot of momentum in a short space.
 %Requires%
@@ -421,8 +461,9 @@ Varies (stunt, movement)
 When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
 
 - An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle.
+//
 
-# Center
+[Center]
 %Fluff%
 Slow down.  Take a breath, in and then out.  Forget your cause, forget your opponent.  Feel the wapon, move with it, *strike*.
 You have developed a kind of battle-trance, in which your combat instincts are heightened.
@@ -434,32 +475,36 @@ Sustained.
 Your Trance Bonus is your equal to your ranks in Control ÷ 10.  You gain your Trance Bonus to your INIT.
 %Special%
 No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur.
+//
 
-# Centered Strike
+[Centered Strike]
 %Fluff%
 While centered, you strike with extra force.
 %Requirements%
 the *Center* power, 20 ranks in Control
 %Effect%
 While sustaining Center, You gain +Trance Bonus to your DV.
+//
 
-# Centered Defence
+[Centered Defence]
 %Fluff%
 While centered, your defence is improved.
 %Requirements%
 the *Center* power, 20 ranks in Control, 10 ranks in Fray
 %Effect%
 While sustaining *Center*, you gain +10 to your defence.
+//
 
-# Denial
+[Denial]
 %Fluff%
 While in your battle-trance, your defence is nearly perfect.
 %Requirements%
 the *Centered Defence* power, 20 ranks in Fray
 %Effect%
 If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)
+//
 
-# Shieldwall
+[Shieldwall]
 %Fluff%
 You are expert in the use of large shields, and your defence with them is extraordinary.
 %Requirements%
@@ -469,16 +514,18 @@ If you are using a Heater Shield, Tower Shield or similar large shield, then, wh
 
 - Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
 - While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)
+//
 
-# Brawler's Instinct
+[Brawler's Instinct]
 %Fluff%
 Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight.
 %Requirement%
 10 ranks in Perception, 10 ranks in two *combat* skills.
 %Effect%
 You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you.
+//
 
-# Brawler's Sense
+[Brawler's Sense]
 %Fluff%
 Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has...
 %Requirements%
@@ -491,8 +538,9 @@ While sustaining this power, you gain *Brawler's Sense* as a sense.
 - This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
 - This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
 - What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty.
+//
 
-# Bound Fighter
+[Bound Fighter]
 %Fluff%
 Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up.
 %Requirements%
@@ -505,8 +553,9 @@ When you are *bound*, you can still make an unarmed attack against someone who c
 You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden.
 %Special%
 Critical hits with this attack may weaken or break weaker bindings, like ropes.
+//
 
-# Burried Alive
+[Burried Alive]
 %Fluff%
 The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
 This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through).
@@ -520,8 +569,9 @@ Roll your Unarmed Combat, against your opponents Feat of Strength or React Quick
 You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power.
 %Special%
 Instead of immobilizing your opponent, you can instead attempt to completely burry them.  This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate.
+//
 
-# Hurl an Ally
+[Hurl an Ally]
 %Fluff%
 You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands.
 %Requirements%
@@ -540,3 +590,5 @@ You can throw an ally.
 This power represents *throwing* an ally, which is a Standard Action.  Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action).
 %Special%
 If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*
+//
+

--- a/src/datafiles/powers.dat
+++ b/src/datafiles/powers.dat
@@ -1,0 +1,542 @@
+# Fireball
+%Fluff%
+You can manifest a fireball in your hand.
+%Requires%
+10 ranks in Spellcraft
+%Action%
+Quick Action
+%Effect%
+You manifest a ball of fire in your hand.
+
+- After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
+- If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
+- You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
+- The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
+- Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag).
+
+# Exploding Fireball
+%Requires%
+Fireball and 20 ranks in Spellcraft
+%Effect%
+When using the Fireball power, when your fireball expires (either because you dismissed it or because it left contact with you), you may choose to have it explode. Treat this as a Blast effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)
+
+# Intense Fire
+%Requires%
+20 ranks in Spellcraft
+%Effect%
+Your fire spells do an additional 1d10 DV of damage and have AP -1.
+
+# Jump
+%Requires%
+10 ranks in Spellcraft
+%Action%
+Quick Action
+%Effect%
+You teleport, moving up to twice your Running movement.
+
+# Group Jump
+%Requires%
+Jump, 20 ranks in Spellcraft
+%Effect%
+when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft.
+
+# Long Jump
+%Requires%
+Jump, 20 ranks in Spellcraft
+%Action%
+Standard Action
+%Effect%
+You teleport, moving up to 10 times your Running movement.
+
+# Journey
+%Requires%
+Long Jump, 30 ranks in Spellcraft
+%Action%
+Task Action (1 minute)
+%Effect%
+You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft.
+
+# Pilot
+%Requires%
+Journey, Group Jump
+%Action%
+Task Action (10 minutes)
+%Effect%
+You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network.
+
+# Master
+%Requires%
+10 Control
+%Action%
+Sustained
+%Effect%
+You can use your own intrinsic magic to control (and fortify) your own life processes.
+
+- While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
+- While sustaining this power, you gain +1 Armor.
+
+# Down-Time
+%Fluff%
+You can enter a deep, meditative state, in which you can nourish, refresh and repair both your mind and body.
+%Requires%
+Transcend, 20 Control
+%Action%
+4-Hour Task Action
+%Effect%
+- After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
+- After completing the Sleight, you recover 1d10÷3 Stress.
+- While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day.
+- Special: if you have the Heal Sleight, you may also sustain it during Down Time.
+
+# Fortify
+%Requires%
+20 Control
+%Action%
+Sustained
+%Effect%
+You can fortify your physical and mental abilities.
+
+- While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
+- (Your derived stats would also change, as normal.)
+
+# Heal
+%Requires%
+10 Control
+%Action%
+Sustained
+%Effect%
+Your wounds begin to heal.
+
+- While sustaining this power, you have Fast Healing 1.
+- While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2.
+- Special: if you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check.
+
+# Transfer
+%Requires%
+10 Control
+%Action%
+Sustained
+%Condition%
+To use this power, you must be touching one other creature (which must have a DUR rating).
+%Effects%
+You transfer wounds from a creature that you touch to yourself.
+
+- For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
+- This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons.
+
+# Regrowth
+%Requires%
+Heal, 20 Control
+%Action%
+Task Action (1 Hour)
+%Effect%
+Roll a Control check. If you succeed, you heal one wound.
+
+# Sacrifice
+%Requires%
+Transfer, 20 Control
+%Action%
+Task Action (1 minute)
+%Condition%
+To use this power, you must be sustaining Transfer
+%Effect%
+You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound. (Note: the wound is not *bound*, it is entirely healed.)
+
+- Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted.
+
+# Join
+%Requires%
+10 Ranks in Control
+%Action%
+Sustained
+%Condition%
+To use this Power, you must be touching one character; this character is the target of the Power. If you loose physical contact with the target, the power ends.
+%Effect%
+You join minds with the target, creating a Gestalt. Normally, this is an equal blending; however, under some circumstances – particularly if the target is unwilling – the two minds might fight for dominance over the Gestalt. Treat this as an opposed WIL&times;3 check, with the winner gaining dominance, and thereafter being able to direct the actions of the gestalt.
+
+- The gestalt mind has access to the skills, knowledge and memories of both individuals. The gestalt mind will also express the desires of both minds – even if one mind has become dominant, the other mind in the Gestalt cannot be suppressed completely.
+- Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
+- Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
+- For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have.
+
+# Link
+%Requires%
+Join, 20 Ranks in Control
+%Action%
+Task Action (5 minutes)
+%Condition%
+To use this power, you must be sustaining Join.
+
+- While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
+- The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends.
+
+# Collective
+%Requires%
+Join, Link, 30 Ranks in Control
+%Condition%
+You must be sustaining Join, and you must have Linked with the target.
+
+- You can incorporate more than one mind into the Gestalt created by Join. To add a new mind, you must use Join on that mind, and you must then Link that mind.
+- To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
+- Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
+and they can even potentially assist one-another. However, being a component of a large collective that is not at peace with itself can be a traumatic experience for all involved, even the “victors” in the fight for dominance.
+
+# Shield Bash
+%Requires%
+10 Ranks in Blunt Weapons
+%Effect%
+you can hurt people with a shield about as well as other people can with a weapon. You can use your shield as a weapon, using your Blunt Weapons skill and doing 1d10+2+DB DV (AP -).
+
+# Sneak Attack
+%Requires%
+10 ranks in an Attack skill.
+%Effect%
+You are particularly good at striking weak spots. When you attack an unaware or helpless target, you inflict an additional 1d10 DV.
+
+# Blur
+%Requires%
+10 Ranks in Spellcraft, 10 Ranks in Stealth
+%Action%
+Sustained
+%Effect%
+You become translucent, making you hard to spot.
+
+- You gain +10 bonus to Stealth checks to avoid being seen.
+%Special%
+The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it.
+
+# Vanish
+%Requires%
+Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth
+%Effect%
+Your Blur improves; you become so difficult to spot that others may fail to notice you even if you are standing in plain sight.
+
+- You gain (another) +10 bonus to Stealth checks to avoid being seen.
+- You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier.
+%Special%
+Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft.
+
+# Charm
+%Requires%
+10 Ranks in Persuasion, 10 Ranks in Spellcraft
+%Action%
+Task Action (5 Minutes)
+%Effect%
+Conversation with you is enchanting, in a very literal sense.
+
+- As you spend time in conversation with someone, you can exert a magical influence over them.
+- Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
+- This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably.
+
+# Push
+%Requires%
+Charm, 20 Ranks in Spellcraft
+%Effect%
+You have the ability to “push” your will onto other people.
+
+- When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability.
+
+# Weave
+%Requires%
+10 Ranks in Athletics, 10 Ranks in Fray
+%Action%
+Standard Action
+%Effect%
+You are particularly good at evasive movement.
+
+- In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
+- You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
+- You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
+- This power is unnecessary now that we added evasive movement back.
+
+# Quick Counter
+%Requires%
+10 Ranks in Unarmed Combat dunno about that
+%Action%
+Quick Action
+%Effect%
+You are very good at countering your opponents attacks with a nasty joint lock.
+
+- Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you.
+
+# Quick Break
+%Requires%
+Quick Counter, 20 Ranks in Unarmed Combat
+%Effect%
+When you counter an opponent, you may instead choose to break a joint.
+
+- When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound.
+
+# Blank
+%Requires%
+20 Ranks in Deception
+%Action%
+Sustained
+%Effect%
+Though it requires some concentration, you have an uncanny ability to blank your expression, replacing it with pleasant neutral demeanor.
+
+- While sustaining this power, Read checks made against you suffer a -30 penalty.
+- However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks.
+
+# Conjure
+%Requires%
+10 Ranks in Spellcraft
+%Action%
+Sustained
+%Effect%
+You can form magic into physical forms, which can mimic simple objects.
+
+- While you sustain this power, you can create either three items with cost category Minor, or one object with cost category Medium.
+- You choose the objects when you first use the Power.
+- The objects cannot have complex clockwork, cannot be alchemical or otherwise magic, and cannot sustain chemical reactions; you can form cups, knives, jugs, bags, and blades, for example; but you cannot summon potions, explosives, clocks, food or living creatures.
+- The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
+- The objects works just like their mundane versions; they don’t hover or act on their own, for example.
+
+# Eidolon
+%Requires%
+Conjure, 10 Ranks in Control, 20 Ranks in Spellcraft
+%Action%
+Sustained
+%Effect%
+You can form magic into the shape of a living creature, and you can fracture your mind so that you can control them.
+
+- You get one creature, hereafter called an Eidolon.
+- Each Eidolon is Small, has 15 DUR and 20 STR, has a movement of Walking 3/9, has Normal Senses, and has the Spirit, Humanoid and Eidolon tags.  As magical apparitions, they don’t need to eat, drink, breath or sleep.
+- The Eidolon does not have a mind of its own; rather, you control its actions, as if it was an extension of your body.  This means that it uses your Aptitudes and Skill Ranks; appropriate powers, classes and traits may also be used through your Eidolon, at the GM’s discretion.
+- Mechanically, the you can use your actions to either act through your Character, or to have your Eidolon act.  So, for example, during your turn you could use a Quick Action to have your character move, and a Standard Action to attack with your Eidolon.
+- You may choose three bonuses for the Eidolon from the Bonuses list.
+%Bonuses%
+- Carapace: the Eidolon has a sturdy shell, thick hide, or is otherwise reinforced; it gains 4 Armor.
+- Claws: the Eidolon gains claws:
+- Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural Weapon, Off-Hand.
+- Form: the Eidolon gains the appearance of an animal; it appears to be a normal creature of the given type. (Its stats don’t change, and it is immediately obvious to anyone with Mage Sight that it is a magical conjuration.)
+- Regen: the Eidolon has Fast Healing 2.
+- Sense: the Eidolon gains the benefit of one of your Senses.  (e.g. if you have Magesight, then you may give the Eidolon Mage Sight.)
+- Size: the Eidolon is Size Medium.
+- Sturdy: the Eidolon has +10 DUR and +5 STR.
+- Wings: the Eidolon has wings; it gains the following movement mode: Fly (5/15)
+%Unique Drawbacks%
+Some races have unique drawbacks — for example, the fact that Clay Men are *blind*.
+
+- These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
+Because of this, GM's have the option of declaring a certain feature of a character to be a "major drawback"; they can then require that that character's Eidolon exibit that drawback.
+For example, a GM could declare that a Clay Man's *blind* trait is a "major drawback," and thus their eidolon is *also* blind.
+- We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
+Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see.
+
+# Enhanced Eidolon
+%Requires%
+Eidolon, 20 Ranks in Spellcraft
+%Effect%
+you have more Bonuses available. You can select from the following list, as well as the Bonus list above:
+
+- Ethereal: the Eidolon can become intangible for short periods of time. It gains the following Power:
+  - Action: Quick Action
+  - Effect: the Eidolon becomes intangible. Until its next turn, it can pass straight through solid objects, and solid objects will pass through it. This means it cannot be damaged by weapons, but it also means that it cannot (practically) attack other Creatures, or interact with objects.
+- Fire: a fire simmers within the Eidolon, and it can flare forth. The fire provides illumination like a torch. The Eidolon also gains the following Power:
+  - Action: Sustained
+  - Effect: the Eidolon flares forth, becoming a creature of flame. Anything in contact with it suffers 1D10 damage.  Its natural attacks gain the Fire tag, and cause an additional 1D10 DV.
+- Frost: the Eidolon is suffused with frost, appearing to be made from chipped ice. The Eidolon gains +2 Armor and +5 DUR, and it gains the following Power:
+  - Action: Standard
+  - Effect: the Eidolon can freeze something that it touches. Treat this as a Touch-Only Attack. If it hits, the target suffers 1D10 DV.
+- Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
+  - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m
+
+# Eidolons
+%Requires%
+Eidolon
+%Effect%
+When you activate the Eidolon power, you can create a second Eidolon; if you do, each Eidolon only gets two Bonuses.
+
+# Imbue
+%Requires%
+Eidolon, 20 ranks in Control
+%Effect%
+You can fracture your mind, producing a copy of your consciousness for each Eidolon that you have.
+
+- While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
+- It’s still your mind controlling them, so you control them, and you’re aware of what they see and do.
+
+# Protection
+%Requires%
+*Attendant of the Mourner* Class
+%Action%
+Sustained
+%Effect%
+You gain +3 armor, and those you choose within 5m of you gain +2 armor.
+
+# Rallying Cry
+%Fluff%
+You can inspire others to bravery and heroism even in the direst of circumstances.
+%Requires%
+10 Ranks in a Social Skill, 10 Ranks in a Combat Skill
+%Action%
+Quick Action
+%Effect%
+Roll one of your Social Skills (the GM must approve of your choice).  If you succeed, you *inspire* those nearby (they gain the Brave trait) for 1 turn per 10 points of MoS.
+
+- Normally, you would inspire every ally who can see and hear you, although this might not be the case under unusual circumstances (your GM will decide this).
+- Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all.
+%Special%
+The GM may allow you to inspire those around you if you do something particularly heroic: it might be inspiring just to see you burst out of bonds or rise again in spite of grievous wounds.
+
+# Diving Strike
+%Fluff%
+You've perfected a diving strike, using the momentum of your fall to strengthen your attack.
+%Requires%
+10 ranks in Athletics, 10 ranks in a *melee combat* skill.
+%Action%
+Quick Action (Movement)
+%Effect%
+When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)
+
+# Reckless Dive
+%Fluff%
+Through some mix of talent, luck, bravery and foolishness, you can drop on targets from great heights, and usually hurt them a lot worse than you hurt yourself.
+%Requires%
+the *Diving Strike* power, 20 ranks in Athletics
+%Effect%
+When you make a Diving Strike, any fall damage that you take is also added to your attack's damage.  (You still take the given fall damage.)
+
+- For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage.
+
+# Rough Landing
+%Fluff%
+Luckily, your opponent broke your fall!
+%Requires%
+the *Reckless Dive* power, 20 ranks in Athletics
+%Effect%
+When you use your Reckless Dive power, you may reduce the damage that you take by 1d10; your opponent still takes the full falling damage.
+
+- For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage).
+
+# Acrobatic Strike
+%Fluff%
+By kicking off walls, flipping over obstacles or otherwise acrobatically exploiting your environment, you can build up a lot of momentum in a short space.
+%Requires%
+20 ranks in Athletics, 10 ranks in a *melee combat* skill.
+%Action%
+Varies (stunt, movement)
+%Effect%
+When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
+
+- An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle.
+
+# Center
+%Fluff%
+Slow down.  Take a breath, in and then out.  Forget your cause, forget your opponent.  Feel the wapon, move with it, *strike*.
+You have developed a kind of battle-trance, in which your combat instincts are heightened.
+%Requires%
+10 Ranks in Control, 10 ranks in a combat skill.
+%Action%
+Sustained.
+%Effect%
+Your Trance Bonus is your equal to your ranks in Control ÷ 10.  You gain your Trance Bonus to your INIT.
+%Special%
+No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur.
+
+# Centered Strike
+%Fluff%
+While centered, you strike with extra force.
+%Requirements%
+the *Center* power, 20 ranks in Control
+%Effect%
+While sustaining Center, You gain +Trance Bonus to your DV.
+
+# Centered Defence
+%Fluff%
+While centered, your defence is improved.
+%Requirements%
+the *Center* power, 20 ranks in Control, 10 ranks in Fray
+%Effect%
+While sustaining *Center*, you gain +10 to your defence.
+
+# Denial
+%Fluff%
+While in your battle-trance, your defence is nearly perfect.
+%Requirements%
+the *Centered Defence* power, 20 ranks in Fray
+%Effect%
+If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)
+
+# Shieldwall
+%Fluff%
+You are expert in the use of large shields, and your defence with them is extraordinary.
+%Requirements%
+20 ranks in Fray
+%Effect%
+If you are using a Heater Shield, Tower Shield or similar large shield, then, while using a Full Defense action, you are considered to be in cover from direction of your shield.  (This means that you cannot be directly attacked from that side.)
+
+- Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
+- While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)
+
+# Brawler's Instinct
+%Fluff%
+Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight.
+%Requirement%
+10 ranks in Perception, 10 ranks in two *combat* skills.
+%Effect%
+You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you.
+
+# Brawler's Sense
+%Fluff%
+Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has...
+%Requirements%
+20 ranks in Perception, 20 ranks in Unarmed Combat
+%Action%
+Sustained
+%Effect%
+While sustaining this power, you gain *Brawler's Sense* as a sense.
+
+- This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
+- This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
+- What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty.
+
+# Bound Fighter
+%Fluff%
+Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up.
+%Requirements%
+20 ranks in Unarmed Combat
+%Action%
+Standard Action
+%Effect%
+When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack.
+%Special%
+You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden.
+%Special%
+Critical hits with this attack may weaken or break weaker bindings, like ropes.
+
+# Burried Alive
+%Fluff%
+The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
+This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through).
+%Requirements%
+A burrow speed, 20 ranks in Unarmed Combat
+%Action%
+Standard Action (Maneuver)
+%Effect%
+Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.  If you succeed, you haul your target into your tunnel and partially collapse it.  This immobilizes them.
+%Special%
+You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power.
+%Special%
+Instead of immobilizing your opponent, you can instead attempt to completely burry them.  This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate.
+
+# Hurl an Ally
+%Fluff%
+You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands.
+%Requirements%
+The *Missile-Hurler* class.
+%Action%
+Standard Action
+%Effect%
+You can throw an ally.
+
+- They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
+- If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
+- If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
+- If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
+- They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn.
+%Special%
+This power represents *throwing* an ally, which is a Standard Action.  Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action).
+%Special%
+If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*

--- a/src/datafiles/powers.mostlymd.dat
+++ b/src/datafiles/powers.mostlymd.dat
@@ -1,0 +1,356 @@
+# Fireball
+You can manifest a fireball in your hand.
+- Requires: 10 ranks in Spellcraft
+- Action: Quick Action
+- Effect: You manifest a ball of fire in your hand.
+  - After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
+  - If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
+  - You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
+  - The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
+  - Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag).
+
+# Exploding Fireball
+- Requires: Fireball and 20 ranks in Spellcraft
+- Effect: When using the Fireball power, when your fireball expires (either because you dismissed it or because it left contact with you), you may choose to have it explode. Treat this as a Blast effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)
+
+# Intense Fire
+- Requires: 20 ranks in Spellcraft
+- Effect: Your fire spells do an additional 1d10 DV of damage and have AP -1.
+
+# Jump
+- Requires: 10 ranks in Spellcraft
+- Action: Quick Action
+- Effect: You teleport, moving up to twice your Running movement.
+
+# Group Jump
+- Requires: Jump, 20 ranks in Spellcraft
+- Effect: when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft.
+
+# Long Jump
+- Requires: Jump, 20 ranks in Spellcraft
+- Action: Standard Action
+- Effect: You teleport, moving up to 10 times your Running movement.
+
+# Journey
+- Requires: Long Jump, 30 ranks in Spellcraft
+- Action: Task Action (1 minute)
+- Effect: You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft.
+
+# Pilot
+- Requires: Journey, Group Jump
+- Action: Task Action (10 minutes)
+- Effect: You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network.
+
+# Master
+- Requires: 10 Control
+- Action: Sustained
+- Effect: You can use your own intrinsic magic to control (and fortify) your own life processes.
+  - While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
+  - While sustaining this power, you gain +1 Armor.
+
+# Down-Time
+You can enter a deep, meditative state, in which you can nourish, refresh and repair both your mind and body.
+- Requires: Transcend, 20 Control
+- Action: 4-Hour Task Action
+- Effect:
+  - After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
+  - After completing the Sleight, you recover 1d10÷3 Stress.
+  - While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day.
+  - Special: if you have the Heal Sleight, you may also sustain it during Down Time.
+
+# Fortify
+- Requires: 20 Control
+- Action: Sustained
+- Effect: you can fortify your physical and mental abilities.
+  - While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
+  - (Your derived stats would also change, as normal.)
+
+# Heal
+- Requires: 10 Control
+- Action: Sustained
+- Effect: Your wounds begin to heal.
+  - While sustaining this power, you have Fast Healing 1.
+  - While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2.
+  - Special: if you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check.
+
+# Transfer
+- Requires: 10 Control
+- Action: Sustained
+- Condition: To use this power, you must be touching one other creature (which must have a DUR rating).
+- Effects: You transfer wounds from a creature that you touch to yourself.
+  - For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
+  - This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons.
+
+# Regrowth
+- Requires: Heal, 20 Control
+- Action: Task Action (1 Hour)
+- Effect: Roll a Control check. If you succeed, you heal one wound.
+
+# Sacrifice
+- Requires: Transfer, 20 Control
+- Action: Task Action (1 minute)
+- Condition: To use this power, you must be sustaining Transfer
+- Effect: You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound. (Note: the wound is not *bound*, it is entirely healed.)
+- Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted.
+
+# Join
+- Requires: 10 Ranks in Control
+- Action: Sustained
+- Condition: To use this Power, you must be touching one character; this character is the target of the Power. If you loose physical contact with the target, the power ends.
+- Effect: You join minds with the target, creating a Gestalt. Normally, this is an equal blending; however, under some circumstances – particularly if the target is unwilling – the two minds might fight for dominance over the Gestalt. Treat this as an opposed WIL&times;3 check, with the winner gaining dominance, and thereafter being able to direct the actions of the gestalt.
+- The gestalt mind has access to the skills, knowledge and memories of both individuals. The gestalt mind will also express the desires of both minds – even if one mind has become dominant, the other mind in the Gestalt cannot be suppressed completely.
+- Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
+- Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
+- For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have.
+
+# Link
+- Requires: Join, 20 Ranks in Control
+- Action: Task Action (5 minutes)
+- Condition: To use this power, you must be sustaining Join.
+- While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
+- The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends.
+
+# Collective
+- Requires: Join, Link, 30 Ranks in Control
+- Condition: You must be sustaining Join, and you must have Linked with the target.
+- You can incorporate more than one mind into the Gestalt created by Join. To add a new mind, you must use Join on that mind, and you must then Link that mind.
+- To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
+- Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
+and they can even potentially assist one-another. However, being a component of a large collective that is not at peace with itself can be a traumatic experience for all involved, even the “victors” in the fight for dominance.
+
+# Shield Bash
+- Requires: 10 Ranks in Blunt Weapons
+- Effect: you can hurt people with a shield about as well as other people can with a weapon. You can use your shield as a weapon, using your Blunt Weapons skill and doing 1d10+2+DB DV (AP -).
+
+# Sneak Attack
+- Requires: 10 ranks in an Attack skill.
+- Effect: You are particularly good at striking weak spots. When you attack an unaware or helpless target, you inflict an additional 1d10 DV.
+
+# Blur
+- Requires: 10 Ranks in Spellcraft, 10 Ranks in Stealth
+- Action: Sustained
+- Effect: You become translucent, making you hard to spot.
+  - You gain +10 bonus to Stealth checks to avoid being seen.
+- Special: The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it.
+
+# Vanish
+- Requires: Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth
+- Effect: Your Blur improves; you become so difficult to spot that others may fail to notice you even if you are standing in plain sight.
+  - You gain (another) +10 bonus to Stealth checks to avoid being seen.
+  - You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier.
+- Special: Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft.
+
+# Charm
+- Requires: 10 Ranks in Persuasion, 10 Ranks in Spellcraft
+- Action: Task Action (5 Minutes)
+- Effect: Conversation with you is enchanting, in a very literal sense.
+  - As you spend time in conversation with someone, you can exert a magical influence over them.
+  - Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
+  - This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably.
+
+# Push
+- Requires: Charm, 20 Ranks in Spellcraft
+- Effect: you have the ability to “push” your will onto other people.
+  - When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability.
+
+# Weave
+- Requires: 10 Ranks in Athletics, 10 Ranks in Fray
+- Action: Standard Action
+- Effect: You are particularly good at evasive movement.
+  - In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
+  - You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
+  - You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
+- This power is unnecessary now that we added evasive movement back.
+
+# Quick Counter
+- Requires: 10 Ranks in Unarmed Combat dunno about that
+- Action: Quick Action
+- Effect: You are very good at countering your opponents attacks with a nasty joint lock.
+  - Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you.
+
+# Quick Break
+- Requires: Quick Counter, 20 Ranks in Unarmed Combat
+- Effect: when you counter an opponent, you may instead choose to break a joint.
+  - When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound.
+
+# Blank
+- Requires: 20 Ranks in Deception
+- Action: Sustained
+- Effect: though it requires some concentration, you have an uncanny ability to blank your expression, replacing it with pleasant neutral demeanor.
+  - While sustaining this power, Read checks made against you suffer a -30 penalty.
+  - However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks.
+
+# Conjure
+- Requires: 10 Ranks in Spellcraft
+- Action: Sustained
+- Effect: you can form magic into physical forms, which can mimic simple objects.
+  - While you sustain this power, you can create either three items with cost category Minor, or one object with cost category Medium.
+  - You choose the objects when you first use the Power.
+  - The objects cannot have complex clockwork, cannot be alchemical or otherwise magic, and cannot sustain chemical reactions; you can form cups, knives, jugs, bags, and blades, for example; but you cannot summon potions, explosives, clocks, food or living creatures.
+  - The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
+  - The objects works just like their mundane versions; they don’t hover or act on their own, for example.
+
+# Eidolon
+- Requires: Conjure, 10 Ranks in Control, 20 Ranks in Spellcraft
+- Action: Sustained
+- Effect: you can form magic into the shape of a living creature, and you can fracture your mind so that you can control them.
+  - You get one creature, hereafter called an Eidolon.
+  - Each Eidolon is Small, has 15 DUR and 20 STR, has a movement of Walking 3/9, has Normal Senses, and has the Spirit, Humanoid and Eidolon tags.  As magical apparitions, they don’t need to eat, drink, breath or sleep.
+  - The Eidolon does not have a mind of its own; rather, you control its actions, as if it was an extension of your body.  This means that it uses your Aptitudes and Skill Ranks; appropriate powers, classes and traits may also be used through your Eidolon, at the GM’s discretion.
+  - Mechanically, the you can use your actions to either act through your Character, or to have your Eidolon act.  So, for example, during your turn you could use a Quick Action to have your character move, and a Standard Action to attack with your Eidolon.
+  - You may choose three bonuses for the Eidolon from the Bonuses list.
+- Bonuses:
+  - Carapace: the Eidolon has a sturdy shell, thick hide, or is otherwise reinforced; it gains 4 Armor.
+  - Claws: the Eidolon gains claws:
+      - Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural Weapon, Off-Hand.
+  - Form: the Eidolon gains the appearance of an animal; it appears to be a normal creature of the given type. (Its stats don’t change, and it is immediately obvious to anyone with Mage Sight that it is a magical conjuration.)
+  - Regen: the Eidolon has Fast Healing 2.
+  - Sense: the Eidolon gains the benefit of one of your Senses.  (e.g. if you have Magesight, then you may give the Eidolon Mage Sight.)
+  - Size: the Eidolon is Size Medium.
+  - Sturdy: the Eidolon has +10 DUR and +5 STR.
+  - Wings: the Eidolon has wings; it gains the following movement mode: Fly (5/15)
+- Unique Drawbacks:
+  - Some races have unique drawbacks — for example, the fact that Clay Men are *blind*.
+    These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
+    Because of this, GM's have the option of declaring a certain feature of a character to be a "major drawback"; they can then require that that character's Eidolon exibit that drawback.
+    For example, a GM could declare that a Clay Man's *blind* trait is a "major drawback," and thus their eidolon is *also* blind.
+  - We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
+    Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see.
+
+# Enhanced Eidolon
+- Requires: Eidolon, 20 Ranks in Spellcraft
+- Effect: you have more Bonuses available. You can select from the following list, as well as the Bonus list above:
+  - Ethereal: the Eidolon can become intangible for short periods of time. It gains the following Power:
+    - Action: Quick Action
+    - Effect: the Eidolon becomes intangible. Until its next turn, it can pass straight through solid objects, and solid objects will pass through it. This means it cannot be damaged by weapons, but it also means that it cannot (practically) attack other Creatures, or interact with objects.
+  - Fire: a fire simmers within the Eidolon, and it can flare forth. The fire provides illumination like a torch. The Eidolon also gains the following Power:
+    - Action: Sustained
+    - Effect: the Eidolon flares forth, becoming a creature of flame. Anything in contact with it suffers 1D10 damage.  Its natural attacks gain the Fire tag, and cause an additional 1D10 DV.
+  - Frost: the Eidolon is suffused with frost, appearing to be made from chipped ice. The Eidolon gains +2 Armor and +5 DUR, and it gains the following Power:
+    - Action: Standard
+    - Effect: the Eidolon can freeze something that it touches. Treat this as a Touch-Only Attack. If it hits, the target suffers 1D10 DV.
+  - Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
+    - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m
+
+# Eidolons
+- Requires: Eidolon
+- Effect: When you activate the Eidolon power, you can create a second Eidolon; if you do, each Eidolon only gets two Bonuses.
+
+# Imbue
+- Requires: Eidolon, 20 ranks in Control
+- Effect: you can fracture your mind, producing a copy of your consciousness for each Eidolon that you have.
+  - While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
+  - It’s still your mind controlling them, so you control them, and you’re aware of what they see and do.
+
+# Protection
+- Requires: *Attendant of the Mourner* Class
+- Action: Sustained
+- Effect: You gain +3 armor, and those you choose within 5m of you gain +2 armor.
+
+# Rallying Cry
+You can inspire others to bravery and heroism even in the direst of circumstances.
+- **Requires:** 10 Ranks in a Social Skill, 10 Ranks in a Combat Skill
+- **Action:** Quick Action
+- **Effect:** Roll one of your Social Skills (the GM must approve of your choice).  If you succeed, you *inspire* those nearby (they gain the Brave trait) for 1 turn per 10 points of MoS.
+  - Normally, you would inspire every ally who can see and hear you, although this might not be the case under unusual circumstances (your GM will decide this).
+  - Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all.
+- **Special:** The GM may allow you to inspire those around you if you do something particularly heroic: it might be inspiring just to see you burst out of bonds or rise again in spite of grievous wounds.
+
+# Diving Strike
+You've perfected a diving strike, using the momentum of your fall to strengthen your attack.
+- **Requires:** 10 ranks in Athletics, 10 ranks in a *melee combat* skill.
+- **Action:** Quick Action (Movement)
+- **Effect:** When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)
+
+# Reckless Dive
+Through some mix of talent, luck, bravery and foolishness, you can drop on targets from great heights, and usually hurt them a lot worse than you hurt yourself.
+- **Requires:** the *Diving Strike* power, 20 ranks in Athletics
+- **Effect:** When you make a Diving Strike, any fall damage that you take is also added to your attack's damage.  (You still take the given fall damage.)
+  - For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage.
+
+# Rough Landing
+Luckily, your opponent broke your fall!
+- **Requires:** the *Reckless Dive* power, 20 ranks in Athletics
+- **Effect:** When you use your Reckless Dive power, you may reduce the damage that you take by 1d10; your opponent still takes the full falling damage.
+  - For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage).
+
+# Acrobatic Strike
+By kicking off walls, flipping over obstacles or otherwise acrobatically exploiting your environment, you can build up a lot of momentum in a short space.
+- **Requires** 20 ranks in Athletics, 10 ranks in a *melee combat* skill.
+- **Action** Varies (stunt, movement)
+- **Effect:** When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
+  - An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle.
+
+# Center
+Slow down.  Take a breath, in and then out.  Forget your cause, forget your opponent.  Feel the wapon, move with it, *strike*.
+You have developed a kind of battle-trance, in which your combat instincts are heightened.
+- **Requires:** 10 Ranks in Control, 10 ranks in a combat skill.
+- **Action:** Sustained.
+- **Effect:** Your Trance Bonus is your equal to your ranks in Control ÷ 10.  You gain your Trance Bonus to your INIT.
+- **Special:** No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur.
+
+# Centered Strike
+While centered, you strike with extra force.
+- **Requirements:** the *Center* power, 20 ranks in Control
+- **Effect:** WhilStance | You adopt a e sustaining Center, You gain +Trance Bonus to your DV.
+
+# Centered Defence
+While centered, your defence is improved.
+- **Requirements:** the *Center* power, 20 ranks in Control, 10 ranks in Fray
+- **Effect:** While sustaining *Center*, you gain +10 to your defence.
+
+# Denial
+While in your battle-trance, your defence is nearly perfect.
+- **Requirements:** the *Centered Defence* power, 20 ranks in Fray
+- **Effect:** If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)
+
+# Shieldwall
+You are expert in the use of large shields, and your defence with them is extraordinary.
+- **Requirements:** 20 ranks in Fray
+- **Effect:** If you are using a Heater Shield, Tower Shield or similar large shield, then, while using a Full Defense action, you are considered to be in cover from direction of your shield.  (This means that you cannot be directly attacked from that side.)
+  - Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
+  - While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)
+
+# Brawler's Instinct
+Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight.
+- **Requirement:** 10 ranks in Perception, 10 ranks in two *combat* skills.
+- **Effect:** You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you.
+
+# Brawler's Sense
+Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has...
+- **Requirements:** 20 ranks in Perception, 20 ranks in Unarmed Combat
+- **Action:** Sustained
+- **Effect:** While sustaining this power, you gain *Brawler's Sense* as a sense.
+  - This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
+  - This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
+  - What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty.
+
+# Bound Fighter
+Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up.
+- **Requirements:** 20 ranks in Unarmed Combat
+- **Action:** Standard Action
+- **Effect:** When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack.
+- **Special:** You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden.
+- **Special:** Critical hits with this attack may weaken or break weaker bindings, like ropes.
+
+# Burried Alive
+The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
+This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through).
+- **Requirements:** A burrow speed, 20 ranks in Unarmed Combat
+- **Action:** Standard Action (Maneuver)
+- **Effect:** Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.  If you succeed, you haul your target into your tunnel and partially collapse it.  This immobilizes them.
+- **Special:** You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power.
+- **Special:** Instead of immobilizing your opponent, you can instead attempt to completely burry them.  This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate.
+
+# Hurl an Ally
+You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands.
+- **Requirements:** The *Missile-Hurler* class.
+- **Action:** Standard Action
+- **Effect:** You can throw an ally.
+  - They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
+  - If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
+  - If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
+  - If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
+    - They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn.
+- **Special:** This power represents *throwing* an ally, which is a Standard Action.  Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action).
+- **Special:** If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*

--- a/src/datafiles/powers.toml
+++ b/src/datafiles/powers.toml
@@ -1,0 +1,608 @@
+# A list of powers.
+
+[[Powers]]
+Name = "Fireball"
+General = true
+Fluff = "You can manifest a fireball in your hand."
+Requires = "10 ranks in Spellcraft"
+Action = "Quick Action"
+Effect = """
+You manifest a ball of fire in your hand.
+
+- After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
+- If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
+- You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
+- The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
+- Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag)."""
+
+[[Powers]]
+Name = "Exploding Fireball"
+General = true
+Requires = "Fireball and 20 ranks in Spellcraft"
+Effect = "When using the Fireball power, when your fireball expires (either because you dismissed it or because it left contact with you), you may choose to have it explode. Treat this as a Blast effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)"
+
+[[Powers]]
+Name = "Intense Fire"
+General = true
+Requires = "20 ranks in Spellcraft"
+Effect = "Your fire spells do an additional 1d10 DV of damage and have AP -1."
+
+[[Powers]]
+Name = "Jump"
+General = true
+Requires = "10 ranks in Spellcraft"
+Action = "Quick Action"
+Effect = "You teleport, moving up to twice your Running movement."
+
+[[Powers]]
+Name = "Group Jump"
+General = true
+Requires = "Jump, 20 ranks in Spellcraft"
+Effect = "when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft."
+
+[[Powers]]
+Name = "Long Jump"
+General = true
+Requires = "Jump, 20 ranks in Spellcraft"
+Action = "Standard Action"
+Effect = "You teleport, moving up to 10 times your Running movement."
+
+[[Powers]]
+Name = "Journey"
+General = true
+Requires = "Long Jump, 30 ranks in Spellcraft"
+Action = "Task Action (1 minute)"
+Effect = "You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft."
+
+[[Powers]]
+Name = "Pilot"
+General = true
+Requires = "Journey, Group Jump"
+Action = "Task Action (10 minutes)"
+Effect = "You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network."
+
+[[Powers]]
+Name = "Master"
+General = true
+Requires = "10 ranks in Control"
+Action = "Sustained"
+Effect = """
+You can use your own intrinsic magic to control (and fortify) your own life processes.
+
+- While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
+- While sustaining this power, you gain +1 Armor."""
+
+[[Powers]]
+Name = "Down-Time"
+General = true
+Fluff = "You can enter a deep, meditative state, in which you can nourish, refresh and repair both your mind and body."
+Requires = "Transcend, 20 Control"
+Action = "4-Hour Task Action"
+Effect = """
+- After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
+- After completing the Sleight, you recover 1d10÷3 Stress.
+- While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day."""
+[[Powers.Section]]
+Label = "Special"
+Content = "If you have the Heal Sleight, you may also sustain it during Down Time."
+
+[[Powers]]
+Name = "Fortify"
+General = true
+Requires = "20 ranks in Control"
+Action = "Sustained"
+Effect = """
+You can fortify your physical and mental abilities.
+
+- While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
+- (Your derived stats would also change, as normal.)"""
+
+[[Powers]]
+Name = "Heal"
+General = true
+Requires = "10 Control"
+Action = "Sustained"
+Effect = """
+Your wounds begin to heal.
+
+- While sustaining this power, you have Fast Healing 1.
+- While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2."""
+[[Powers.Section]]
+Label = "Special"
+Content = "If you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check."
+
+[[Powers]]
+Name = "Transfer"
+General = true
+Requires = "10 Control"
+Action = "Sustained"
+Condition = "To use this power, you must be touching one other creature (which must have a DUR rating)."
+Effects = """
+You transfer wounds from a creature that you touch to yourself.
+
+- For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
+- This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons."""
+
+[[Powers]]
+Name = "Regrowth"
+General = true
+Requires = "Heal, 20 Control"
+Action = "Task Action (1 Hour)"
+Effect = "Roll a Control check. If you succeed, you heal one wound."
+
+[[Powers]]
+Name = "Sacrifice"
+General = true
+Requires = "Transfer, 20 Control"
+Action = "Task Action (1 minute)"
+Condition = "To use this power, you must be sustaining Transfer"
+Effect = """
+You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound. (Note: the wound is not *bound*, it is entirely healed.)
+
+- Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted."""
+
+[[Powers]]
+Name = "Join"
+General = true
+Requires = "10 Ranks in Control"
+Action = "Sustained"
+Condition = "To use this Power, you must be touching one character; this character is the target of the Power. If you loose physical contact with the target, the power ends."
+Effect = """
+You join minds with the target, creating a Gestalt. Normally, this is an equal blending; however, under some circumstances – particularly if the target is unwilling – the two minds might fight for dominance over the Gestalt. Treat this as an opposed WIL&times;3 check, with the winner gaining dominance, and thereafter being able to direct the actions of the gestalt.
+
+- The gestalt mind has access to the skills, knowledge and memories of both individuals. The gestalt mind will also express the desires of both minds – even if one mind has become dominant, the other mind in the Gestalt cannot be suppressed completely.
+- Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
+- Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
+- For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have."""
+
+[[Powers]]
+Name = "Link"
+General = true
+Requires = "Join, 20 Ranks in Control"
+Action = "Task Action (5 minutes)"
+Condition = """
+To use this power, you must be sustaining Join.
+
+- While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
+- The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends."""
+
+[[Powers]]
+Name = "Collective"
+General = true
+Requires = "Join, Link, 30 Ranks in Control"
+Condition = """
+You must be sustaining Join, and you must have Linked with the target.
+
+- You can incorporate more than one mind into the Gestalt created by Join. To add a new mind, you must use Join on that mind, and you must then Link that mind.
+- To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
+- Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
+and they can even potentially assist one-another. However, being a component of a large collective that is not at peace with itself can be a traumatic experience for all involved, even the “victors” in the fight for dominance."""
+
+[[Powers]]
+Name = "Shield Bash"
+General = true
+Requires = "10 Ranks in Blunt Weapons"
+Effect = """
+You can hurt people with a shield about as well as other people can with a weapon.
+You can use your shield as a weapon, using your Blunt Weapons skill and doing 1d10+2+DB DV (AP -)."""
+
+[[Powers]]
+Name = "Sneak Attack"
+General = true
+Requires = "10 ranks in an Attack skill."
+Effect = """
+You are particularly good at striking weak spots.
+When you attack an unaware or helpless target, you inflict an additional 1d10 DV."""
+
+[[Powers]]
+Name = "Blur"
+General = true
+Requires = "10 Ranks in Spellcraft, 10 Ranks in Stealth"
+Action = "Sustained"
+Effect = """
+You become translucent, making you hard to spot.
+
+- You gain +10 bonus to Stealth checks to avoid being seen."""
+[[Powers.Section]]
+Label = "Special"
+Content = "The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it."
+
+[[Powers]]
+Name = "Vanish"
+General = true
+Requires = "Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth"
+Effect = """
+Your Blur improves; you become so difficult to spot that others may fail to notice you even if you are standing in plain sight.
+
+- You gain (another) +10 bonus to Stealth checks to avoid being seen.
+- You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier."""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft."""
+
+[[Powers]]
+Name = "Charm"
+General = true
+Requires = "10 Ranks in Persuasion, 10 Ranks in Spellcraft"
+Action = "Task Action (5 Minutes)"
+Effect = """
+Conversation with you is enchanting, in a very literal sense.
+
+- As you spend time in conversation with someone, you can exert a magical influence over them.
+- Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
+- This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably."""
+
+[[Powers]]
+Name = "Push"
+General = true
+Requires = """
+Charm, 20 Ranks in Spellcraft"""
+Effect = """
+You have the ability to “push” your will onto other people.
+
+- When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability."""
+
+[[Powers]]
+Name = "Weave"
+General = true
+Requires = """
+10 Ranks in Athletics, 10 Ranks in Fray"""
+Action = """
+Standard Action"""
+Effect = """
+You are particularly good at evasive movement.
+
+- In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
+- You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
+- You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
+- This power is unnecessary now that we added evasive movement back."""
+
+[[Powers]]
+Name = "Quick Counter"
+General = true
+Requires = """
+10 Ranks in Unarmed Combat dunno about that"""
+Action = """
+Quick Action"""
+Effect = """
+You are very good at countering your opponents attacks with a nasty joint lock.
+
+- Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you."""
+
+[[Powers]]
+Name = "Quick Break"
+General = true
+Requires = """
+Quick Counter, 20 Ranks in Unarmed Combat"""
+Effect = """
+When you counter an opponent, you may instead choose to break a joint.
+
+- When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound."""
+
+[[Powers]]
+Name = "Blank"
+General = true
+Requires = """
+20 Ranks in Deception"""
+Action = """
+Sustained"""
+Effect = """
+Though it requires some concentration, you have an uncanny ability to blank your expression, replacing it with pleasant neutral demeanor.
+
+- While sustaining this power, Read checks made against you suffer a -30 penalty.
+- However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks."""
+
+[[Powers]]
+Name = "Conjure"
+General = true
+Requires = """
+10 Ranks in Spellcraft"""
+Action = """
+Sustained"""
+Effect = """
+You can form magic into physical forms, which can mimic simple objects.
+
+- While you sustain this power, you can create either three items with cost category Minor, or one object with cost category Medium.
+- You choose the objects when you first use the Power.
+- The objects cannot have complex clockwork, cannot be alchemical or otherwise magic, and cannot sustain chemical reactions; you can form cups, knives, jugs, bags, and blades, for example; but you cannot summon potions, explosives, clocks, food or living creatures.
+- The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
+- The objects works just like their mundane versions; they don’t hover or act on their own, for example."""
+
+[[Powers]]
+Name = "Eidolon"
+General = true
+Requires = """
+Conjure, 10 Ranks in Control, 20 Ranks in Spellcraft"""
+Action = """
+Sustained"""
+Effect = """
+You can form magic into the shape of a living creature, and you can fracture your mind so that you can control them.
+
+- You get one creature, hereafter called an Eidolon.
+- Each Eidolon is Small, has 15 DUR and 20 STR, has a movement of Walking 3/9, has Normal Senses, and has the Spirit, Humanoid and Eidolon tags.  As magical apparitions, they don’t need to eat, drink, breath or sleep.
+- The Eidolon does not have a mind of its own; rather, you control its actions, as if it was an extension of your body.  This means that it uses your Aptitudes and Skill Ranks; appropriate powers, classes and traits may also be used through your Eidolon, at the GM’s discretion.
+- Mechanically, the you can use your actions to either act through your Character, or to have your Eidolon act.  So, for example, during your turn you could use a Quick Action to have your character move, and a Standard Action to attack with your Eidolon.
+- You may choose three bonuses for the Eidolon from the Bonuses list."""
+Bonuses = """
+- Carapace: the Eidolon has a sturdy shell, thick hide, or is otherwise reinforced; it gains 4 Armor.
+- Claws: the Eidolon gains claws:
+- Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural Weapon, Off-Hand.
+- Form: the Eidolon gains the appearance of an animal; it appears to be a normal creature of the given type. (Its stats don’t change, and it is immediately obvious to anyone with Mage Sight that it is a magical conjuration.)
+- Regen: the Eidolon has Fast Healing 2.
+- Sense: the Eidolon gains the benefit of one of your Senses.  (e.g. if you have Magesight, then you may give the Eidolon Mage Sight.)
+- Size: the Eidolon is Size Medium.
+- Sturdy: the Eidolon has +10 DUR and +5 STR.
+- Wings: the Eidolon has wings; it gains the following movement mode: Fly (5/15)"""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+Some races have unique drawbacks — for example, the fact that Clay Men are *blind*.
+
+- These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
+Because of this, GM's have the option of declaring a certain feature of a character to be a "major drawback"; they can then require that that character's Eidolon exibit that drawback.
+For example, a GM could declare that a Clay Man's *blind* trait is a "major drawback," and thus their eidolon is *also* blind.
+- We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
+Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see."""
+
+[[Powers]]
+Name = "Enhanced Eidolon"
+General = true
+Requires = """
+Eidolon, 20 Ranks in Spellcraft"""
+Effect = """
+you have more Bonuses available. You can select from the following list, as well as the Bonus list above:
+
+- Ethereal: the Eidolon can become intangible for short periods of time. It gains the following Power:
+  - Action: Quick Action
+  - Effect: the Eidolon becomes intangible. Until its next turn, it can pass straight through solid objects, and solid objects will pass through it. This means it cannot be damaged by weapons, but it also means that it cannot (practically) attack other Creatures, or interact with objects.
+- Fire: a fire simmers within the Eidolon, and it can flare forth. The fire provides illumination like a torch. The Eidolon also gains the following Power:
+  - Action: Sustained
+  - Effect: the Eidolon flares forth, becoming a creature of flame. Anything in contact with it suffers 1D10 damage.  Its natural attacks gain the Fire tag, and cause an additional 1D10 DV.
+- Frost: the Eidolon is suffused with frost, appearing to be made from chipped ice. The Eidolon gains +2 Armor and +5 DUR, and it gains the following Power:
+  - Action: Standard
+  - Effect: the Eidolon can freeze something that it touches. Treat this as a Touch-Only Attack. If it hits, the target suffers 1D10 DV.
+- Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
+  - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m"""
+
+[[Powers]]
+Name = "Eidolons"
+General = true
+Requires = """
+Eidolon"""
+Effect = """
+When you activate the Eidolon power, you can create a second Eidolon; if you do, each Eidolon only gets two Bonuses."""
+
+[[Powers]]
+Name = "Imbue"
+General = true
+Requires = """
+Eidolon, 20 ranks in Control"""
+Effect = """
+You can fracture your mind, producing a copy of your consciousness for each Eidolon that you have.
+
+- While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
+- It’s still your mind controlling them, so you control them, and you’re aware of what they see and do."""
+
+[[Powers]]
+Name = "Protection"
+General = true
+Requires = """
+*Attendant of the Mourner* Class"""
+Action = """
+Sustained"""
+Effect = """
+You gain +3 armor, and those you choose within 5m of you gain +2 armor."""
+
+[[Powers]]
+Name = "Rallying Cry"
+General = true
+Fluff = "You can inspire others to bravery and heroism even in the direst of circumstances."
+Requires = "10 Ranks in a Social Skill, 10 Ranks in a Combat Skill"
+Action = "Quick Action"
+Effect = """
+Roll one of your Social Skills (the GM must approve of your choice).  If you succeed, you *inspire* those nearby (they gain the Brave trait) for 1 turn per 10 points of MoS.
+
+- Normally, you would inspire every ally who can see and hear you, although this might not be the case under unusual circumstances (your GM will decide this).
+- Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all."""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+The GM may allow you to inspire those around you if you do something particularly heroic: it might be inspiring just to see you burst out of bonds or rise again in spite of grievous wounds."""
+
+[[Powers]]
+Name = "Diving Strike"
+General = true
+Fluff = """
+You've perfected a diving strike, using the momentum of your fall to strengthen your attack."""
+Requires = """
+10 ranks in Athletics, 10 ranks in a *melee combat* skill."""
+Action = """
+Quick Action (Movement)"""
+Effect = """
+When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)"""
+
+[[Powers]]
+Name = "Reckless Dive"
+General = true
+Fluff = """
+Through some mix of talent, luck, bravery and foolishness, you can drop on targets from great heights, and usually hurt them a lot worse than you hurt yourself."""
+Requires = """
+the *Diving Strike* power, 20 ranks in Athletics"""
+Effect = """
+When you make a Diving Strike, any fall damage that you take is also added to your attack's damage.  (You still take the given fall damage.)
+
+- For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage."""
+
+[[Powers]]
+Name = "Rough Landing"
+General = true
+Fluff = """
+Luckily, your opponent broke your fall!"""
+Requires = """
+the *Reckless Dive* power, 20 ranks in Athletics"""
+Effect = """
+When you use your Reckless Dive power, you may reduce the damage that you take by 1d10; your opponent still takes the full falling damage.
+
+- For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage)."""
+
+[[Powers]]
+Name = "Acrobatic Strike"
+General = true
+Fluff = """
+By kicking off walls, flipping over obstacles or otherwise acrobatically exploiting your environment, you can build up a lot of momentum in a short space."""
+Requires = "20 ranks in Athletics, 10 ranks in a *melee combat* skill."
+Action = "Varies (stunt, movement)"
+Effect = """
+When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
+
+- An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle."""
+
+[[Powers]]
+Name = "Center"
+General = true
+Fluff = """
+Slow down.  Take a breath, in and then out.  Forget your cause, forget your opponent.  Feel the wapon, move with it, *strike*.
+You have developed a kind of battle-trance, in which your combat instincts are heightened."""
+Requires = """
+10 Ranks in Control, 10 ranks in a combat skill."""
+Action = """
+Sustained."""
+Effect = """
+Your Trance Bonus is your equal to your ranks in Control ÷ 10.  You gain your Trance Bonus to your INIT."""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur."""
+
+[[Powers]]
+Name = "Centered Strike"
+General = true
+Fluff = """
+While centered, you strike with extra force."""
+Requirements = """
+the *Center* power, 20 ranks in Control"""
+Effect = """
+While sustaining Center, You gain +Trance Bonus to your DV."""
+
+[[Powers]]
+Name = "Centered Defence"
+General = true
+Fluff = """
+While centered, your defence is improved."""
+Requirements = """
+the *Center* power, 20 ranks in Control, 10 ranks in Fray"""
+Effect = """
+While sustaining *Center*, you gain +10 to your defence."""
+
+[[Powers]]
+Name = "Denial"
+General = true
+Fluff = """
+While in your battle-trance, your defence is nearly perfect."""
+Requirements = """
+the *Centered Defence* power, 20 ranks in Fray"""
+Effect = """
+If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)"""
+
+[[Powers]]
+Name = "Shieldwall"
+General = true
+Fluff = """
+You are expert in the use of large shields, and your defence with them is extraordinary."""
+Requirements = """
+20 ranks in Fray"""
+Effect = """
+If you are using a Heater Shield, Tower Shield or similar large shield, then, while using a Full Defense action, you are considered to be in cover from direction of your shield.  (This means that you cannot be directly attacked from that side.)
+
+- Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
+- While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)"""
+
+[[Powers]]
+Name = "Brawler's Instinct"
+General = true
+Fluff = """
+Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight."""
+Requirement = """
+10 ranks in Perception, 10 ranks in two *combat* skills."""
+Effect = """
+You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you."""
+
+[[Powers]]
+Name = "Brawler's Sense"
+General = true
+Fluff = """
+Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has..."""
+Requirements = """
+20 ranks in Perception, 20 ranks in Unarmed Combat"""
+Action = """
+Sustained"""
+Effect = """
+While sustaining this power, you gain *Brawler's Sense* as a sense.
+
+- This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
+- This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
+- What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty."""
+
+[[Powers]]
+Name = "Bound Fighter"
+General = true
+Fluff = """
+Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up."""
+Requirements = """
+20 ranks in Unarmed Combat"""
+Action = """
+Standard Action"""
+Effect = """
+When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack."""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden."""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+Critical hits with this attack may weaken or break weaker bindings, like ropes."""
+
+[[Powers]]
+Name = "Burried Alive"
+General = true
+Fluff = """
+The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
+This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through)."""
+Requirements = "A burrow speed, 20 ranks in Unarmed Combat"
+Action = "Standard Action (Maneuver)"
+Effect = """
+Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.  If you succeed, you haul your target into your tunnel and partially collapse it.  This immobilizes them."""
+[[Powers.Section]]
+Label = "Special"
+Content = "You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power."
+[[Powers.Section]]
+Label = "Special"
+Content = """
+Instead of immobilizing your opponent, you can instead attempt to completely burry them.  This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate."""
+
+[[Powers]]
+Name = "Hurl an Ally"
+General = true
+Fluff = """
+You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands."""
+Requirements = "The *Missile-Hurler* class."
+Action = "Standard Action"
+Effect = """
+You can throw an ally.
+
+- They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
+- If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
+- If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
+- If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
+- They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn."""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+This power represents *throwing* an ally, which is a Standard Action.
+Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action)."""
+[[Powers.Section]]
+Label = "Special"
+Content = """
+If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*"""

--- a/src/datafiles/powers.toml
+++ b/src/datafiles/powers.toml
@@ -1,12 +1,12 @@
 # A list of powers.
 
-[[Powers]]
-Name = "Fireball"
-General = true
-Fluff = "You can manifest a fireball in your hand."
-Requires = "10 ranks in Spellcraft"
-Action = "Quick Action"
-Effect = """
+[[powers]]
+name = "Fireball"
+general = true
+fluff = "You can manifest a fireball in your hand."
+requires = "10 ranks in Spellcraft"
+action = "Quick Action"
+effect = """
 You manifest a ball of fire in your hand.
   - After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
   - If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
@@ -14,289 +14,289 @@ You manifest a ball of fire in your hand.
   - The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
   - Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag)."""
 
-[[Powers]]
-Name = "Exploding Fireball"
-General = true
-Requires = "Fireball and 20 ranks in Spellcraft"
-Effect = "When using the Fireball power, when your fireball expires (either because you dismissed it or because it left contact with you), you may choose to have it explode. Treat this as a Blast effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)"
+[[powers]]
+name = "Exploding Fireball"
+general = true
+requires = "Fireball and 20 ranks in Spellcraft"
+effect = "When using the Fireball power, when your fireball expires (either because you dismissed it or because it left contact with you), you may choose to have it explode. Treat this as a Blast effect, which does your fireball’s damage.  (See the rules for Blast effects in Combat)"
 
-[[Powers]]
-Name = "Intense Fire"
-General = true
-Requires = "20 ranks in Spellcraft"
-Effect = "Your fire spells do an additional 1d10 DV of damage and have AP -1."
+[[powers]]
+name = "Intense Fire"
+general = true
+requires = "20 ranks in Spellcraft"
+effect = "Your fire spells do an additional 1d10 DV of damage and have AP -1."
 
-[[Powers]]
-Name = "Jump"
-General = true
-Requires = "10 ranks in Spellcraft"
-Action = "Quick Action"
-Effect = "You teleport, moving up to twice your Running movement."
+[[powers]]
+name = "Jump"
+general = true
+requires = "10 ranks in Spellcraft"
+action = "Quick Action"
+effect = "You teleport, moving up to twice your Running movement."
 
-[[Powers]]
-Name = "Group Jump"
-General = true
-Requires = "Jump, 20 ranks in Spellcraft"
-Effect = "when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft."
+[[powers]]
+name = "Group Jump"
+general = true
+requires = "Jump, 20 ranks in Spellcraft"
+effect = "when you teleport, you may take objects or other people with you. You may carry either one normal-sized person or 50 Kg of cargo per 10 ranks in Spellcraft."
 
-[[Powers]]
-Name = "Long Jump"
-General = true
-Requires = "Jump, 20 ranks in Spellcraft"
-Action = "Standard Action"
-Effect = "You teleport, moving up to 10 times your Running movement."
+[[powers]]
+name = "Long Jump"
+general = true
+requires = "Jump, 20 ranks in Spellcraft"
+action = "Standard Action"
+effect = "You teleport, moving up to 10 times your Running movement."
 
-[[Powers]]
-Name = "Journey"
-General = true
-Requires = "Long Jump, 30 ranks in Spellcraft"
-Action = "Task Action (1 minute)"
-Effect = "You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft."
+[[powers]]
+name = "Journey"
+general = true
+requires = "Long Jump, 30 ranks in Spellcraft"
+action = "Task Action (1 minute)"
+effect = "You teleport, moving up to 2 kilometer per 10 ranks in Spellcraft."
 
-[[Powers]]
-Name = "Pilot"
-General = true
-Requires = "Journey, Group Jump"
-Action = "Task Action (10 minutes)"
-Effect = "You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network."
+[[powers]]
+name = "Pilot"
+general = true
+requires = "Journey, Group Jump"
+action = "Task Action (10 minutes)"
+effect = "You can use a Kairne to teleport; when you do so, you can teleport to any other Kairne in the network."
 
-[[Powers]]
-Name = "Master"
-General = true
-Requires = "10 ranks in Control"
-Action = "Sustained"
-Effect = """
+[[powers]]
+name = "Master"
+general = true
+requires = "10 ranks in Control"
+action = "Sustained"
+effect = """
 You can use your own intrinsic magic to control (and fortify) your own life processes.
   - While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
   - While sustaining this power, you gain +1 Armor."""
 
-[[Powers]]
-Name = "Down-Time"
-General = true
-Fluff = "You can enter a deep, meditative state, in which you can nourish, refresh and repair both your mind and body."
-Requires = "Transcend, 20 Control"
-Action = "4-Hour Task Action"
-Effect = """
+[[powers]]
+name = "Down-Time"
+general = true
+fluff = "You can enter a deep, meditative state, in which you can nourish, refresh and repair both your mind and body."
+requires = "Transcend, 20 Control"
+action = "4-Hour Task Action"
+effect = """
 \n  - After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
   - After completing the Sleight, you recover 1d10÷3 Stress.
   - While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "If you have the Heal Sleight, you may also sustain it during Down Time."
+[[powers.sections]]
+label = "Special"
+content = "If you have the Heal Sleight, you may also sustain it during Down Time."
 
-[[Powers]]
-Name = "Fortify"
-General = true
-Requires = "20 ranks in Control"
-Action = "Sustained"
-Effect = """
+[[powers]]
+name = "Fortify"
+general = true
+requires = "20 ranks in Control"
+action = "Sustained"
+effect = """
 You can fortify your physical and mental abilities.
   - While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
   - (Your derived stats would also change, as normal.)"""
 
-[[Powers]]
-Name = "Heal"
-General = true
-Requires = "10 Control"
-Action = "Sustained"
-Effect = """
+[[powers]]
+name = "Heal"
+general = true
+requires = "10 Control"
+action = "Sustained"
+effect = """
 Your wounds begin to heal.
   - While sustaining this power, you have Fast Healing 1.
   - While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "If you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check."
+[[powers.sections]]
+label = "Special"
+content = "If you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check."
 
-[[Powers]]
-Name = "Transfer"
-General = true
-Requires = "10 Control"
-Action = "Sustained"
-Effect = """
+[[powers]]
+name = "Transfer"
+general = true
+requires = "10 Control"
+action = "Sustained"
+effect = """
 You transfer wounds from a creature that you touch to yourself.
   - For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
   - This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "To use this power, you must be touching one other creature, and that creature must have a DUR rating."
+[[powers.sections]]
+label = "Special"
+content = "To use this power, you must be touching one other creature, and that creature must have a DUR rating."
 
-[[Powers]]
-Name = "Regrowth"
-General = true
-Requires = "Heal, 20 Control"
-Action = "Task Action (1 Hour)"
-Effect = "Roll a Control check. If you succeed, you heal one wound."
+[[powers]]
+name = "Regrowth"
+general = true
+requires = "Heal, 20 Control"
+action = "Task Action (1 Hour)"
+effect = "Roll a Control check. If you succeed, you heal one wound."
 
-[[Powers]]
-Name = "Sacrifice"
-General = true
-Requires = "Transfer, 20 Control"
-Action = "Task Action (1 minute)"
-Effect = """
+[[powers]]
+name = "Sacrifice"
+general = true
+requires = "Transfer, 20 Control"
+action = "Task Action (1 minute)"
+effect = """
 You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound. (Note: the wound is not *bound*, it is entirely healed.)
   - Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "To use this power, you must be sustaining Transfer."
+[[powers.sections]]
+label = "Special"
+content = "To use this power, you must be sustaining Transfer."
 
-[[Powers]]
-Name = "Join"
-General = true
-Requires = "10 Ranks in Control"
-Action = "Sustained"
-Effect = """
+[[powers]]
+name = "Join"
+general = true
+requires = "10 Ranks in Control"
+action = "Sustained"
+effect = """
 You join minds with the target, creating a Gestalt. Normally, this is an equal blending; however, under some circumstances – particularly if the target is unwilling – the two minds might fight for dominance over the Gestalt. Treat this as an opposed WIL&times;3 check, with the winner gaining dominance, and thereafter being able to direct the actions of the gestalt.
   - The gestalt mind has access to the skills, knowledge and memories of both individuals. The gestalt mind will also express the desires of both minds – even if one mind has become dominant, the other mind in the Gestalt cannot be suppressed completely.
   - Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
   - Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
   - For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have."""
-[[Powers.Sections]]
-Label = "Special"
-Content = """
+[[powers.sections]]
+label = "Special"
+content = """
 To use this Power, you must be touching one character; this character is the target of the Power.
 If you loose physical contact with the target, the power ends."""
 
-[[Powers]]
-Name = "Link"
-General = true
-Requires = "Join, 20 Ranks in Control"
-Action = "Task Action (5 minutes)"
-Effect="""You link your mind with the target's.
+[[powers]]
+name = "Link"
+general = true
+requires = "Join, 20 Ranks in Control"
+action = "Task Action (5 minutes)"
+effect = """You link your mind with the target's.
   - While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
   - The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "To use this power, you must be sustaining Join."
+[[powers.sections]]
+label = "Special"
+content = "To use this power, you must be sustaining Join."
 
 
-[[Powers]]
-Name = "Collective"
-General = true
-Requires = "Join, Link, 30 Ranks in Control"
-Effect = """
+[[powers]]
+name = "Collective"
+general = true
+requires = "Join, Link, 30 Ranks in Control"
+effect = """
 \n  - You can incorporate more than one mind into the Gestalt created by Join. To add a new mind, you must use Join on that mind, and you must then Link that mind.
   - To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
   - Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
 and they can even potentially assist one-another. However, being a component of a large collective that is not at peace with itself can be a traumatic experience for all involved, even the “victors” in the fight for dominance."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "To use this power, you must be sustaining Join, and you must have linked with the target."
+[[powers.sections]]
+label = "Special"
+content = "To use this power, you must be sustaining Join, and you must have linked with the target."
 
-[[Powers]]
-Name = "Shield Bash"
-General = true
-Requires = "10 Ranks in Blunt Weapons"
-Effect = """
+[[powers]]
+name = "Shield Bash"
+general = true
+requires = "10 Ranks in Blunt Weapons"
+effect = """
 You can hurt people with a shield about as well as other people can with a weapon.
 You can use your shield as a weapon, using your Blunt Weapons skill and doing 1d10+2+DB DV (AP -)."""
 
-[[Powers]]
-Name = "Sneak Attack"
-General = true
-Requires = "10 ranks in an Attack skill."
-Effect = """
+[[powers]]
+name = "Sneak Attack"
+general = true
+requires = "10 ranks in an Attack skill."
+effect = """
 You are particularly good at striking weak spots.
 When you attack an unaware or helpless target, you inflict an additional 1d10 DV."""
 
-[[Powers]]
-Name = "Blur"
-General = true
-Requires = "10 Ranks in Spellcraft, 10 Ranks in Stealth"
-Action = "Sustained"
-Effect = """
+[[powers]]
+name = "Blur"
+general = true
+requires = "10 Ranks in Spellcraft, 10 Ranks in Stealth"
+action = "Sustained"
+effect = """
 You become translucent, making you hard to spot.
   - You gain +10 bonus to Stealth checks to avoid being seen."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it."
+[[powers.sections]]
+label = "Special"
+content = "The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it."
 
-[[Powers]]
-Name = "Vanish"
-General = true
-Requires = "Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth"
-Effect = """
+[[powers]]
+name = "Vanish"
+general = true
+requires = "Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth"
+effect = """
 Your Blur improves; you become so difficult to spot that others may fail to notice you even if you are standing in plain sight.
   - You gain (another) +10 bonus to Stealth checks to avoid being seen.
   - You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier."""
-[[Powers.Sections]]
-Label = "Special"
-Content = """
+[[powers.sections]]
+label = "Special"
+content = """
 Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft."""
 
-[[Powers]]
-Name = "Charm"
-General = true
-Requires = "10 Ranks in Persuasion, 10 Ranks in Spellcraft"
-Action = "Task Action (5 Minutes)"
-Effect = """
+[[powers]]
+name = "Charm"
+general = true
+requires = "10 Ranks in Persuasion, 10 Ranks in Spellcraft"
+action = "Task Action (5 Minutes)"
+effect = """
 Conversation with you is enchanting, in a very literal sense.
   - As you spend time in conversation with someone, you can exert a magical influence over them.
   - Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
   - This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably."""
 
-[[Powers]]
-Name = "Push"
-General = true
-Requires = """
+[[powers]]
+name = "Push"
+general = true
+requires = """
 Charm, 20 Ranks in Spellcraft"""
-Effect = """
+effect = """
 You have the ability to “push” your will onto other people.
   - When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability."""
 
-[[Powers]]
-Name = "Weave"
-General = true
-Requires = """
+[[powers]]
+name = "Weave"
+general = true
+requires = """
 10 Ranks in Athletics, 10 Ranks in Fray"""
-Action = """
+action = """
 Standard Action"""
-Effect = """
+effect = """
 You are particularly good at evasive movement.
   - In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
   - You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
   - You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
   - This power is unnecessary now that we added evasive movement back."""
 
-[[Powers]]
-Name = "Quick Counter"
-General = true
-Requires = """
+[[powers]]
+name = "Quick Counter"
+general = true
+requires = """
 10 Ranks in Unarmed Combat dunno about that"""
-Action = """
+action = """
 Quick Action"""
-Effect = """
+effect = """
 You are very good at countering your opponents attacks with a nasty joint lock.
   - Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you."""
 
-[[Powers]]
-Name = "Quick Break"
-General = true
-Requires = """
+[[powers]]
+name = "Quick Break"
+general = true
+requires = """
 Quick Counter, 20 Ranks in Unarmed Combat"""
-Effect = """
+effect = """
 When you counter an opponent, you may instead choose to break a joint.
   - When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound."""
 
-[[Powers]]
-Name = "Blank"
-General = true
-Requires = """
+[[powers]]
+name = "Blank"
+general = true
+requires = """
 20 Ranks in Deception"""
-Action = """
+action = """
 Sustained"""
-Effect = """
+effect = """
 Though it requires some concentration, you have an uncanny ability to blank your expression, replacing it with pleasant neutral demeanor.
   - While sustaining this power, Read checks made against you suffer a -30 penalty.
   - However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks."""
 
-[[Powers]]
-Name = "Conjure"
-General = true
-Requires = """
+[[powers]]
+name = "Conjure"
+general = true
+requires = """
 10 Ranks in Spellcraft"""
-Action = """
+action = """
 Sustained"""
-Effect = """
+effect = """
 You can form magic into physical forms, which can mimic simple objects.
   - While you sustain this power, you can create either three items with cost category Minor, or one object with cost category Medium.
   - You choose the objects when you first use the Power.
@@ -304,23 +304,23 @@ You can form magic into physical forms, which can mimic simple objects.
   - The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
   - The objects works just like their mundane versions; they don’t hover or act on their own, for example."""
 
-[[Powers]]
-Name = "Eidolon"
-General = true
-Requires = """
+[[powers]]
+name = "Eidolon"
+general = true
+requires = """
 Conjure, 10 Ranks in Control, 20 Ranks in Spellcraft"""
-Action = """
+action = """
 Sustained"""
-Effect = """
+effect = """
 You can form magic into the shape of a living creature, and you can fracture your mind so that you can control them.
   - You get one creature, hereafter called an Eidolon.
   - Each Eidolon is Small, has 15 DUR and 20 STR, has a movement of Walking 3/9, has Normal Senses, and has the Spirit, Humanoid and Eidolon tags.  As magical apparitions, they don’t need to eat, drink, breath or sleep.
   - The Eidolon does not have a mind of its own; rather, you control its actions, as if it was an extension of your body.  This means that it uses your Aptitudes and Skill Ranks; appropriate powers, classes and traits may also be used through your Eidolon, at the GM’s discretion.
   - Mechanically, the you can use your actions to either act through your Character, or to have your Eidolon act.  So, for example, during your turn you could use a Quick Action to have your character move, and a Standard Action to attack with your Eidolon.
   - You may choose three bonuses for the Eidolon from the Bonuses list."""
-[[Powers.Sections]]
-Label = "Bonuses"
-Content = """
+[[powers.sections]]
+label = "Bonuses"
+content = """
 \n  - Carapace: the Eidolon has a sturdy shell, thick hide, or is otherwise reinforced; it gains 4 Armor.
   - Claws: the Eidolon gains claws:
     - Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural Weapon, Off-Hand.
@@ -330,9 +330,9 @@ Content = """
   - Size: the Eidolon is Size Medium.
   - Sturdy: the Eidolon has +10 DUR and +5 STR.
   - Wings: the Eidolon has wings; it gains the following movement mode: Fly (5/15)"""
-[[Powers.Sections]]
-Label = "Special"
-Content = """
+[[powers.sections]]
+label = "Special"
+content = """
 Some races have unique drawbacks — for example, the fact that Clay Men are *blind*.
   - These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
 Because of this, GM's have the option of declaring a certain feature of a character to be a "major drawback"; they can then require that that character's Eidolon exibit that drawback.
@@ -340,12 +340,12 @@ For example, a GM could declare that a Clay Man's *blind* trait is a "major draw
   - We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
 Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see."""
 
-[[Powers]]
-Name = "Enhanced Eidolon"
-General = true
-Requires = """
+[[powers]]
+name = "Enhanced Eidolon"
+general = true
+requires = """
 Eidolon, 20 Ranks in Spellcraft"""
-Effect = """
+effect = """
 you have more Bonuses available. You can select from the following list, as well as the Bonus list above:
   - Ethereal: the Eidolon can become intangible for short periods of time. It gains the following Power:
     - Action: Quick Action
@@ -359,217 +359,217 @@ you have more Bonuses available. You can select from the following list, as well
   - Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
     - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m"""
 
-[[Powers]]
-Name = "Eidolons"
-General = true
-Requires = """
+[[powers]]
+name = "Eidolons"
+general = true
+requires = """
 Eidolon"""
-Effect = """
+effect = """
 When you activate the Eidolon power, you can create a second Eidolon; if you do, each Eidolon only gets two Bonuses."""
 
-[[Powers]]
-Name = "Imbue"
-General = true
-Requires = """
+[[powers]]
+name = "Imbue"
+general = true
+requires = """
 Eidolon, 20 ranks in Control"""
-Effect = """
+effect = """
 You can fracture your mind, producing a copy of your consciousness for each Eidolon that you have.
   - While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
   - It’s still your mind controlling them, so you control them, and you’re aware of what they see and do."""
 
-[[Powers]]
-Name = "Protection"
-General = true
-Requires = "*Attendant of the Mourner* Class"
-Action = "Sustained"
-Effect = "You gain +3 armor, and those you choose within 5m of you gain +2 armor."
+[[powers]]
+name = "Protection"
+general = true
+requires = "*Attendant of the Mourner* Class"
+action = "Sustained"
+effect = "You gain +3 armor, and those you choose within 5m of you gain +2 armor."
 
-[[Powers]]
-Name = "Rallying Cry"
-General = true
-Fluff = "You can inspire others to bravery and heroism even in the direst of circumstances."
-Requires = "10 Ranks in a Social Skill, 10 Ranks in a Combat Skill"
-Action = "Quick Action"
-Effect = """
+[[powers]]
+name = "Rallying Cry"
+general = true
+fluff = "You can inspire others to bravery and heroism even in the direst of circumstances."
+requires = "10 Ranks in a Social Skill, 10 Ranks in a Combat Skill"
+action = "Quick Action"
+effect = """
 Roll one of your Social Skills (the GM must approve of your choice).  If you succeed, you *inspire* those nearby (they gain the Brave trait) for 1 turn per 10 points of MoS.
   - Normally, you would inspire every ally who can see and hear you, although this might not be the case under unusual circumstances (your GM will decide this).
   - Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all."""
-[[Powers.Sections]]
-Label = "Special"
-Content = """
+[[powers.sections]]
+label = "Special"
+content = """
 The GM may allow you to inspire those around you if you do something particularly heroic: it might be inspiring just to see you burst out of bonds or rise again in spite of grievous wounds."""
 
-[[Powers]]
-Name = "Diving Strike"
-General = true
-Fluff = "You've perfected a diving strike, using the momentum of your fall to strengthen your attack."
-Requires = "10 ranks in Athletics, 10 ranks in a *melee combat* skill."
-Action = "Quick Action (Movement)"
-Effect = """
+[[powers]]
+name = "Diving Strike"
+general = true
+fluff = "You've perfected a diving strike, using the momentum of your fall to strengthen your attack."
+requires = "10 ranks in Athletics, 10 ranks in a *melee combat* skill."
+action = "Quick Action (Movement)"
+effect = """
 When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)"""
 
-[[Powers]]
-Name = "Reckless Dive"
-General = true
-Fluff = """
+[[powers]]
+name = "Reckless Dive"
+general = true
+fluff = """
 Through some mix of talent, luck, bravery and foolishness, you can drop on targets from great heights, and usually hurt them a lot worse than you hurt yourself."""
-Requires = "the *Diving Strike* power, 20 ranks in Athletics"
-Effect = """
+requires = "the *Diving Strike* power, 20 ranks in Athletics"
+effect = """
 When you make a Diving Strike, any fall damage that you take is also added to your attack's damage.  (You still take the given fall damage.)
   - For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage."""
 
-[[Powers]]
-Name = "Rough Landing"
-General = true
-Fluff = "Luckily, your opponent broke your fall!"
-Requires = "the *Reckless Dive* power, 20 ranks in Athletics"
-Effect = """
+[[powers]]
+name = "Rough Landing"
+general = true
+fluff = "Luckily, your opponent broke your fall!"
+requires = "the *Reckless Dive* power, 20 ranks in Athletics"
+effect = """
 When you use your Reckless Dive power, you may reduce the damage that you take by 1d10; your opponent still takes the full falling damage.
   - For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage)."""
 
-[[Powers]]
-Name = "Acrobatic Strike"
-General = true
-Fluff = """
+[[powers]]
+name = "Acrobatic Strike"
+general = true
+fluff = """
 By kicking off walls, flipping over obstacles or otherwise acrobatically exploiting your environment, you can build up a lot of momentum in a short space."""
-Requires = "20 ranks in Athletics, 10 ranks in a *melee combat* skill."
-Action = "Varies (stunt, movement)"
-Effect = """
+requires = "20 ranks in Athletics, 10 ranks in a *melee combat* skill."
+action = "Varies (stunt, movement)"
+effect = """
 When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
   - An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle."""
 
-[[Powers]]
-Name = "Center"
-General = true
-Fluff = """
+[[powers]]
+name = "Center"
+general = true
+fluff = """
 Slow down.  Take a breath, in and then out.  Forget your cause, forget your opponent.  Feel the wapon, move with it, *strike*.
 You have developed a kind of battle-trance, in which your combat instincts are heightened."""
-Requires = """
+requires = """
 10 Ranks in Control, 10 ranks in a combat skill."""
-Action = "Sustained."
-Effect = """
+action = "Sustained."
+effect = """
 Your Trance Bonus is your equal to your ranks in Control ÷ 10.
 You gain your Trance Bonus to your INIT."""
-[[Powers.Sections]]
-Label = "Special"
-Content = """
+[[powers.sections]]
+label = "Special"
+content = """
 No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur."""
 
-[[Powers]]
-Name = "Centered Strike"
-General = true
-Fluff = """
+[[powers]]
+name = "Centered Strike"
+general = true
+fluff = """
 While centered, you strike with extra force."""
-Requires = """
+requires = """
 the *Center* power, 20 ranks in Control"""
-Effect = """
+effect = """
 While sustaining Center, You gain +Trance Bonus to your DV."""
 
-[[Powers]]
-Name = "Centered Defence"
-General = true
-Fluff = "While centered, your defence is improved."
-Requires = "the *Center* power, 20 ranks in Control, 10 ranks in Fray"
-Effect = "While sustaining *Center*, you gain +10 to your defence."
+[[powers]]
+name = "Centered Defence"
+general = true
+fluff = "While centered, your defence is improved."
+requires = "the *Center* power, 20 ranks in Control, 10 ranks in Fray"
+effect = "While sustaining *Center*, you gain +10 to your defence."
 
-[[Powers]]
-Name = "Denial"
-General = true
-Fluff = """
+[[powers]]
+name = "Denial"
+general = true
+fluff = """
 While in your battle-trance, your defence is nearly perfect."""
-Requires = """
+requires = """
 the *Centered Defence* power, 20 ranks in Fray"""
-Effect = """
+effect = """
 If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)"""
 
-[[Powers]]
-Name = "Shieldwall"
-General = true
-Fluff = "You are expert in the use of large shields, and your defence with them is extraordinary."
-Requires = "20 ranks in Fray"
-Effect = """
+[[powers]]
+name = "Shieldwall"
+general = true
+fluff = "You are expert in the use of large shields, and your defence with them is extraordinary."
+requires = "20 ranks in Fray"
+effect = """
 If you are using a Heater Shield, Tower Shield or similar large shield, then, while using a Full Defense action, you are considered to be in cover from direction of your shield.  (This means that you cannot be directly attacked from that side.)
   - Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
   - While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)"""
 
-[[Powers]]
-Name = "Brawler's Instinct"
-General = true
-Fluff = """
+[[powers]]
+name = "Brawler's Instinct"
+general = true
+fluff = """
 Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight."""
-Requires = "10 ranks in Perception, 10 ranks in two *combat* skills."
-Effect = "You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you."
+requires = "10 ranks in Perception, 10 ranks in two *combat* skills."
+effect = "You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you."
 
-[[Powers]]
-Name = "Brawler's Sense"
-General = true
-Fluff = """
+[[powers]]
+name = "Brawler's Sense"
+general = true
+fluff = """
 Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has..."""
-Requires = """
+requires = """
 20 ranks in Perception, 20 ranks in Unarmed Combat"""
-Action = """
+action = """
 Sustained"""
-Effect = """
+effect = """
 While sustaining this power, you gain *Brawler's Sense* as a sense.
   - This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
   - This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
   - What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty."""
 
-[[Powers]]
-Name = "Bound Fighter"
-General = true
-Fluff = """
+[[powers]]
+name = "Bound Fighter"
+general = true
+fluff = """
 Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up."""
-Requires = "20 ranks in Unarmed Combat"
-Action = "Standard Action"
-Effect = "When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack."
-[[Powers.Sections]]
-Label = "Special"
-Content = "You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden."
-[[Powers.Sections]]
-Label = "Special"
-Content = "Critical hits with this attack may weaken or break weaker bindings, like ropes."
+requires = "20 ranks in Unarmed Combat"
+action = "Standard Action"
+effect = "When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack."
+[[powers.sections]]
+label = "Special"
+content = "You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden."
+[[powers.sections]]
+label = "Special"
+content = "Critical hits with this attack may weaken or break weaker bindings, like ropes."
 
-[[Powers]]
-Name = "Burried Alive"
-General = true
-Fluff = """
+[[powers]]
+name = "Burried Alive"
+general = true
+fluff = """
 The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
 This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through)."""
-Requires = "A burrow speed, 20 ranks in Unarmed Combat"
-Action = "Standard Action (Maneuver)"
-Effect = """
+requires = "A burrow speed, 20 ranks in Unarmed Combat"
+action = "Standard Action (Maneuver)"
+effect = """
 Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.
 If you succeed, you haul your target into your tunnel and partially collapse it.
 This immobilizes them."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power."
-[[Powers.Sections]]
-Label = "Special"
-Content = """
+[[powers.sections]]
+label = "Special"
+content = "You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power."
+[[powers.sections]]
+label = "Special"
+content = """
 Instead of immobilizing your opponent, you can instead attempt to completely burry them.
 This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate."""
 
-[[Powers]]
-Name = "Hurl an Ally"
-General = true
-Fluff = """
+[[powers]]
+name = "Hurl an Ally"
+general = true
+fluff = """
 You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands."""
-Requires = "The *Missile-Hurler* class."
-Action = "Standard Action"
-Effect = """
+requires = "The *Missile-Hurler* class."
+action = "Standard Action"
+effect = """
 You can throw an ally.
   - They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
   - If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
   - If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
   - If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
   - They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn."""
-[[Powers.Sections]]
-Label = "Special"
-Content = """
+[[powers.sections]]
+label = "Special"
+content = """
 This power represents *throwing* an ally, which is a Standard Action.
 Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action)."""
-[[Powers.Sections]]
-Label = "Special"
-Content = "If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*"
+[[powers.sections]]
+label = "Special"
+content = "If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*"

--- a/src/datafiles/powers.toml
+++ b/src/datafiles/powers.toml
@@ -573,3 +573,59 @@ Much like drawing a weapon, picking up an ally to throw them requires a separate
 [[powers.sections]]
 label = "Special"
 content = "If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*"
+
+[[powers]]
+name = "Hurl an Ally"
+general = true
+fluff = """
+You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands."""
+requires = "The *Missile-Hurler* class."
+action = "Standard Action"
+effect = """
+You can throw an ally.
+  - They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
+  - If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
+  - If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
+  - If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
+  - They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn."""
+[[powers.sections]]
+label = "Special"
+content = """
+This power represents *throwing* an ally, which is a Standard Action.
+Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action)."""
+[[powers.sections]]
+label = "Special"
+content = "If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*"
+
+[[powers]]
+name = "Parry with the Sheath"
+general = true
+fluff = "Useful for more than just holding the weapon."
+requires = "10 Ranks in Fray, 10 ranks in Melee Combat"
+action = "Reaction"
+effect = """
+When you are attacked in melee, as a reaction, you can add +20 to your defense check.
+  - You are considered to be armed while defending in this way."""
+[[powers.sections]]
+label = "Clarification"
+content = """
+You must declare the use of this power before you roll your defense.
+Normally, you get one reaction per "turn-cycle".
+This power is useful any time you defend, whether you're using fray, taking the full defense action, moving evasively, parrying, or doing something else."""
+[[powers.sections]]
+label = "Special"
+content = """
+To use this power, you must name a sturdy item that you are carrying, that you could grab quickly; good candidates include sheathes, walking sticks, and cooking pans.
+  - The GM must approve of this choice.
+  - If you critically fail on your defense, you drop the item you picked."""
+
+[[powers]]
+name = "Take the Blow"
+general = true
+fluff = "If you're gonna get stabbed, you'd rather the blade turn on your ribs than pass between them."
+requires = "20 Ranks in Fray"
+action = "Automatic"
+effect = "While taking the *full defense* action, whenever you defend with fray, you gain +1 armor per 10 points of MoS."
+[[powers.sections]]
+label = "Special"
+content = "You do not gain this benefit if you are wearing armor with the cumbersome or heavy tags, or carrying a shield with the cumbersome or heavy tags."

--- a/src/datafiles/powers.toml
+++ b/src/datafiles/powers.toml
@@ -8,12 +8,11 @@ Requires = "10 ranks in Spellcraft"
 Action = "Quick Action"
 Effect = """
 You manifest a ball of fire in your hand.
-
-- After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
-- If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
-- You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
-- The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
-- Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag)."""
+  - After it is created, treat the ball of fire as you would any other held object. The ball of fire will not burn you or any possession that you are in contact with, but it will burn other objects (or people).
+  - If the ball of fire looses contact with you (as it will if it is thrown, for example), it can persist for up to 5 turns (about 15 seconds) on its own; otherwise, it can persist as long as you hold on to it.
+  - You can voluntarily dismiss the ball of fire (which is handy, because sleeping with a ball of fire in your hand is ill-advised).
+  - The ball of fire is, of course, fire, and effects other objects as such. (It will burn other people for 1d10 DV, plus 1 per ten ranks of Spellcraft; it may set a character on fire if an exceptional success is scored.)
+  - Clarification: since the ball of fire is treated just like any other small object, it can be thrown at an opponent (using all the rules for a ranged attack with a thrown weapon, doing the listed damage, and having the Fire tag), or it can be pressed into an opponent to burn them (a touch-only attack, doing the listed damage, having the Fire tag)."""
 
 [[Powers]]
 Name = "Exploding Fireball"
@@ -68,9 +67,8 @@ Requires = "10 ranks in Control"
 Action = "Sustained"
 Effect = """
 You can use your own intrinsic magic to control (and fortify) your own life processes.
-
-- While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
-- While sustaining this power, you gain +1 Armor."""
+  - While sustaining this power, you receive a +20 bonus to checks to Endure Physical Hardship.
+  - While sustaining this power, you gain +1 Armor."""
 
 [[Powers]]
 Name = "Down-Time"
@@ -79,10 +77,10 @@ Fluff = "You can enter a deep, meditative state, in which you can nourish, refre
 Requires = "Transcend, 20 Control"
 Action = "4-Hour Task Action"
 Effect = """
-- After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
-- After completing the Sleight, you recover 1d10÷3 Stress.
-- While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day."""
-[[Powers.Section]]
+\n  - After completing the use of this Sleight, you do not need to eat or sleep for 1 day.
+  - After completing the Sleight, you recover 1d10÷3 Stress.
+  - While sustaining this Sleight, you are very difficult to wake; other people will need to shake you violently to wake you (a Standard Action). Other similarly violent actions  will wake you — if the building you are in collapses, or if you are attacked, for example. If you are roused from the Sleight before it completes, you suffer a -10 penalty from the exhaustion and disorientation for 1 day."""
+[[Powers.Sections]]
 Label = "Special"
 Content = "If you have the Heal Sleight, you may also sustain it during Down Time."
 
@@ -93,9 +91,8 @@ Requires = "20 ranks in Control"
 Action = "Sustained"
 Effect = """
 You can fortify your physical and mental abilities.
-
-- While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
-- (Your derived stats would also change, as normal.)"""
+  - While you sustain this Sleight, you receive a +5 bonus to one of your Aptitudes, to your Strength, or to your Durability.
+  - (Your derived stats would also change, as normal.)"""
 
 [[Powers]]
 Name = "Heal"
@@ -104,10 +101,9 @@ Requires = "10 Control"
 Action = "Sustained"
 Effect = """
 Your wounds begin to heal.
-
-- While sustaining this power, you have Fast Healing 1.
-- While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2."""
-[[Powers.Section]]
+  - While sustaining this power, you have Fast Healing 1.
+  - While sustaining this power, you may attempt a Control check as a Quick Action; if you succeed, you instead have Fast Healing 2."""
+[[Powers.Sections]]
 Label = "Special"
 Content = "If you have a few minutes to focus yourself (i.e., when you are out of combat, the GM may allow you to progress to Fast Healing 2 without requiring a check."
 
@@ -116,12 +112,13 @@ Name = "Transfer"
 General = true
 Requires = "10 Control"
 Action = "Sustained"
-Condition = "To use this power, you must be touching one other creature (which must have a DUR rating)."
-Effects = """
+Effect = """
 You transfer wounds from a creature that you touch to yourself.
-
-- For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
-- This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons."""
+  - For every turn that you sustain this power, you take 2 DV; if you do, the creature you are touching is either healed healed for 2 DUR, or one ongoing bleed effect is ended (you choose which).
+  - This power cannot “transfer” wounds in this way, nor can it heal diseases, congenital defects or poisons."""
+[[Powers.Sections]]
+Label = "Special"
+Content = "To use this power, you must be touching one other creature, and that creature must have a DUR rating."
 
 [[Powers]]
 Name = "Regrowth"
@@ -135,48 +132,55 @@ Name = "Sacrifice"
 General = true
 Requires = "Transfer, 20 Control"
 Action = "Task Action (1 minute)"
-Condition = "To use this power, you must be sustaining Transfer"
 Effect = """
 You suffer one wound; if you do, the person you are transferring wounds from is healed for one wound. (Note: the wound is not *bound*, it is entirely healed.)
-
-- Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted."""
+  - Using sacrifice can be stressful. A WIL×3 test can be called for to use this power; if the power is used successfully, Stress might be inflicted."""
+[[Powers.Sections]]
+Label = "Special"
+Content = "To use this power, you must be sustaining Transfer."
 
 [[Powers]]
 Name = "Join"
 General = true
 Requires = "10 Ranks in Control"
 Action = "Sustained"
-Condition = "To use this Power, you must be touching one character; this character is the target of the Power. If you loose physical contact with the target, the power ends."
 Effect = """
 You join minds with the target, creating a Gestalt. Normally, this is an equal blending; however, under some circumstances – particularly if the target is unwilling – the two minds might fight for dominance over the Gestalt. Treat this as an opposed WIL&times;3 check, with the winner gaining dominance, and thereafter being able to direct the actions of the gestalt.
-
-- The gestalt mind has access to the skills, knowledge and memories of both individuals. The gestalt mind will also express the desires of both minds – even if one mind has become dominant, the other mind in the Gestalt cannot be suppressed completely.
-- Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
-- Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
-- For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have."""
+  - The gestalt mind has access to the skills, knowledge and memories of both individuals. The gestalt mind will also express the desires of both minds – even if one mind has become dominant, the other mind in the Gestalt cannot be suppressed completely.
+  - Unsurprisingly, this can be extremely traumatic – this is almost always the case when the target is unwilling.
+  - Physical action is very difficult, given that one character must maintain physical contact with another – but it can be attempted. Appropriate penalties apply (usually -30).
+  - For simplicity, assume that the Gestalt functions as one character, at least in so far as it has one initiative score and has the same allotment of actions that any individual character would have."""
+[[Powers.Sections]]
+Label = "Special"
+Content = """
+To use this Power, you must be touching one character; this character is the target of the Power.
+If you loose physical contact with the target, the power ends."""
 
 [[Powers]]
 Name = "Link"
 General = true
 Requires = "Join, 20 Ranks in Control"
 Action = "Task Action (5 minutes)"
-Condition = """
-To use this power, you must be sustaining Join.
+Effect="""You link your mind with the target's.
+  - While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
+  - The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends."""
+[[Powers.Sections]]
+Label = "Special"
+Content = "To use this power, you must be sustaining Join."
 
-- While sustaining Join, you can Link your mind with the target. Thereafter, as long as you continue to sustain Join, you can break physical contact with the target and maintain the Gestalt. This makes physical action far more feasible.
-- The targets cannot get more than (Your ranks in Control) × 2 meters apart from one-another, or the effect ends."""
 
 [[Powers]]
 Name = "Collective"
 General = true
 Requires = "Join, Link, 30 Ranks in Control"
-Condition = """
-You must be sustaining Join, and you must have Linked with the target.
-
-- You can incorporate more than one mind into the Gestalt created by Join. To add a new mind, you must use Join on that mind, and you must then Link that mind.
-- To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
-- Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
+Effect = """
+\n  - You can incorporate more than one mind into the Gestalt created by Join. To add a new mind, you must use Join on that mind, and you must then Link that mind.
+  - To remain in the Gestalt, ever element of the collective must be within the given range of at least one other element of the collective (they can form a chain).
+  - Fights for dominance among collectives are more complicated. Generally, only two participants should be rolling against each other at any given time. Minds who can co-exist peacefully can nominate the strongest among them to represent their interests,
 and they can even potentially assist one-another. However, being a component of a large collective that is not at peace with itself can be a traumatic experience for all involved, even the “victors” in the fight for dominance."""
+[[Powers.Sections]]
+Label = "Special"
+Content = "To use this power, you must be sustaining Join, and you must have linked with the target."
 
 [[Powers]]
 Name = "Shield Bash"
@@ -201,9 +205,8 @@ Requires = "10 Ranks in Spellcraft, 10 Ranks in Stealth"
 Action = "Sustained"
 Effect = """
 You become translucent, making you hard to spot.
-
-- You gain +10 bonus to Stealth checks to avoid being seen."""
-[[Powers.Section]]
+  - You gain +10 bonus to Stealth checks to avoid being seen."""
+[[Powers.Sections]]
 Label = "Special"
 Content = "The Blur power is partially masked; a character with Mage Sight needs to make a Perception check to detect it."
 
@@ -213,10 +216,9 @@ General = true
 Requires = "Blur, 20 Ranks in Spellcraft, 20 Ranks in Stealth"
 Effect = """
 Your Blur improves; you become so difficult to spot that others may fail to notice you even if you are standing in plain sight.
-
-- You gain (another) +10 bonus to Stealth checks to avoid being seen.
-- You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier."""
-[[Powers.Section]]
+  - You gain (another) +10 bonus to Stealth checks to avoid being seen.
+  - You may use Stealth to avoid being seen even if you do not have anything to hide behind. Such a Stealth check suffers a -20 modifier."""
+[[Powers.Sections]]
 Label = "Special"
 Content = """
 Vanish is more effectively masked; a character with Mage Sight needs to make an opposed perception test to notice it, the spotting character's Perception versus the vanishing character's Spellcraft."""
@@ -228,10 +230,9 @@ Requires = "10 Ranks in Persuasion, 10 Ranks in Spellcraft"
 Action = "Task Action (5 Minutes)"
 Effect = """
 Conversation with you is enchanting, in a very literal sense.
-
-- As you spend time in conversation with someone, you can exert a magical influence over them.
-- Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
-- This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably."""
+  - As you spend time in conversation with someone, you can exert a magical influence over them.
+  - Make an opposed test, your Persuasion versus their Resist Social Manipulation (SAV + INT). If you succeed, they will regard you as a friend, and will view your words and actions in the best possible light.
+  - This does not grant you magical control of their actions, it simply implies that they will trust you and regard you favorably."""
 
 [[Powers]]
 Name = "Push"
@@ -240,8 +241,7 @@ Requires = """
 Charm, 20 Ranks in Spellcraft"""
 Effect = """
 You have the ability to “push” your will onto other people.
-
-- When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability."""
+  - When you Charm someone, you may attempt a Persuasion check, opposed by their Resist Social Manipulation. If you win, then you may give them a single instruction, which they will carry out to the best of their ability."""
 
 [[Powers]]
 Name = "Weave"
@@ -252,11 +252,10 @@ Action = """
 Standard Action"""
 Effect = """
 You are particularly good at evasive movement.
-
-- In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
-- You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
-- You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
-- This power is unnecessary now that we added evasive movement back."""
+  - In combat, you may take a Standard Action to *move evasively*. You may move up to your running rate. Until the beginning of your next turn, you may defend with your Athletics skill, and you gain +20 to your defenses.
+  - You don’t have to actually move from your space to use this power. Using Weave without moving might represent focusing all your attention on parrying incoming blows, for example.
+  - You get the +20 bonus to checks made to defend yourself, whether you use Athletics to defend or not. You can defend with Fray and still get the +20 bonus, for example.
+  - This power is unnecessary now that we added evasive movement back."""
 
 [[Powers]]
 Name = "Quick Counter"
@@ -267,8 +266,7 @@ Action = """
 Quick Action"""
 Effect = """
 You are very good at countering your opponents attacks with a nasty joint lock.
-
-- Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you."""
+  - Until the beginning of your next turn, if you are attacked in melee, defend with your Unarmed Skill, win the opposed check (that is, successfully defend against an attack), and score an Exceptional Success, then you automatically grapple the person who attacked you."""
 
 [[Powers]]
 Name = "Quick Break"
@@ -277,8 +275,7 @@ Requires = """
 Quick Counter, 20 Ranks in Unarmed Combat"""
 Effect = """
 When you counter an opponent, you may instead choose to break a joint.
-
-- When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound."""
+  - When you Quick Counter an opponent, instead of grappling them, you may choose to inflict a single Wound."""
 
 [[Powers]]
 Name = "Blank"
@@ -289,9 +286,8 @@ Action = """
 Sustained"""
 Effect = """
 Though it requires some concentration, you have an uncanny ability to blank your expression, replacing it with pleasant neutral demeanor.
-
-- While sustaining this power, Read checks made against you suffer a -30 penalty.
-- However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks."""
+  - While sustaining this power, Read checks made against you suffer a -30 penalty.
+  - However, because your neutral expression makes it hard to convey your emotional state — and might be a little unnerving — you suffer a -10 penalty to Persuasion checks."""
 
 [[Powers]]
 Name = "Conjure"
@@ -302,12 +298,11 @@ Action = """
 Sustained"""
 Effect = """
 You can form magic into physical forms, which can mimic simple objects.
-
-- While you sustain this power, you can create either three items with cost category Minor, or one object with cost category Medium.
-- You choose the objects when you first use the Power.
-- The objects cannot have complex clockwork, cannot be alchemical or otherwise magic, and cannot sustain chemical reactions; you can form cups, knives, jugs, bags, and blades, for example; but you cannot summon potions, explosives, clocks, food or living creatures.
-- The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
-- The objects works just like their mundane versions; they don’t hover or act on their own, for example."""
+  - While you sustain this power, you can create either three items with cost category Minor, or one object with cost category Medium.
+  - You choose the objects when you first use the Power.
+  - The objects cannot have complex clockwork, cannot be alchemical or otherwise magic, and cannot sustain chemical reactions; you can form cups, knives, jugs, bags, and blades, for example; but you cannot summon potions, explosives, clocks, food or living creatures.
+  - The objects you form are partially translucent, and glow with a ghostly energy; though you can control their appearance up to a point, they are obviously magical creations.
+  - The objects works just like their mundane versions; they don’t hover or act on their own, for example."""
 
 [[Powers]]
 Name = "Eidolon"
@@ -318,31 +313,31 @@ Action = """
 Sustained"""
 Effect = """
 You can form magic into the shape of a living creature, and you can fracture your mind so that you can control them.
-
-- You get one creature, hereafter called an Eidolon.
-- Each Eidolon is Small, has 15 DUR and 20 STR, has a movement of Walking 3/9, has Normal Senses, and has the Spirit, Humanoid and Eidolon tags.  As magical apparitions, they don’t need to eat, drink, breath or sleep.
-- The Eidolon does not have a mind of its own; rather, you control its actions, as if it was an extension of your body.  This means that it uses your Aptitudes and Skill Ranks; appropriate powers, classes and traits may also be used through your Eidolon, at the GM’s discretion.
-- Mechanically, the you can use your actions to either act through your Character, or to have your Eidolon act.  So, for example, during your turn you could use a Quick Action to have your character move, and a Standard Action to attack with your Eidolon.
-- You may choose three bonuses for the Eidolon from the Bonuses list."""
-Bonuses = """
-- Carapace: the Eidolon has a sturdy shell, thick hide, or is otherwise reinforced; it gains 4 Armor.
-- Claws: the Eidolon gains claws:
-- Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural Weapon, Off-Hand.
-- Form: the Eidolon gains the appearance of an animal; it appears to be a normal creature of the given type. (Its stats don’t change, and it is immediately obvious to anyone with Mage Sight that it is a magical conjuration.)
-- Regen: the Eidolon has Fast Healing 2.
-- Sense: the Eidolon gains the benefit of one of your Senses.  (e.g. if you have Magesight, then you may give the Eidolon Mage Sight.)
-- Size: the Eidolon is Size Medium.
-- Sturdy: the Eidolon has +10 DUR and +5 STR.
-- Wings: the Eidolon has wings; it gains the following movement mode: Fly (5/15)"""
-[[Powers.Section]]
+  - You get one creature, hereafter called an Eidolon.
+  - Each Eidolon is Small, has 15 DUR and 20 STR, has a movement of Walking 3/9, has Normal Senses, and has the Spirit, Humanoid and Eidolon tags.  As magical apparitions, they don’t need to eat, drink, breath or sleep.
+  - The Eidolon does not have a mind of its own; rather, you control its actions, as if it was an extension of your body.  This means that it uses your Aptitudes and Skill Ranks; appropriate powers, classes and traits may also be used through your Eidolon, at the GM’s discretion.
+  - Mechanically, the you can use your actions to either act through your Character, or to have your Eidolon act.  So, for example, during your turn you could use a Quick Action to have your character move, and a Standard Action to attack with your Eidolon.
+  - You may choose three bonuses for the Eidolon from the Bonuses list."""
+[[Powers.Sections]]
+Label = "Bonuses"
+Content = """
+\n  - Carapace: the Eidolon has a sturdy shell, thick hide, or is otherwise reinforced; it gains 4 Armor.
+  - Claws: the Eidolon gains claws:
+    - Attack: Unarmed Combat, 1D10+1+DB, -2 AP; Tags: Natural Weapon, Off-Hand.
+  - Form: the Eidolon gains the appearance of an animal; it appears to be a normal creature of the given type. (Its stats don’t change, and it is immediately obvious to anyone with Mage Sight that it is a magical conjuration.)
+  - Regen: the Eidolon has Fast Healing 2.
+  - Sense: the Eidolon gains the benefit of one of your Senses.  (e.g. if you have Magesight, then you may give the Eidolon Mage Sight.)
+  - Size: the Eidolon is Size Medium.
+  - Sturdy: the Eidolon has +10 DUR and +5 STR.
+  - Wings: the Eidolon has wings; it gains the following movement mode: Fly (5/15)"""
+[[Powers.Sections]]
 Label = "Special"
 Content = """
 Some races have unique drawbacks — for example, the fact that Clay Men are *blind*.
-
-- These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
+  - These drawbacks may be an important part of how the race is designed to function — and the Eidolon power may offer an easy way for clever players to bypass these limitations.
 Because of this, GM's have the option of declaring a certain feature of a character to be a "major drawback"; they can then require that that character's Eidolon exibit that drawback.
 For example, a GM could declare that a Clay Man's *blind* trait is a "major drawback," and thus their eidolon is *also* blind.
-- We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
+  - We usually recommend that a player be allowed to use a bonus to negate a "major drawback."
 Arguably, if a Clay Man can give their eidolon the ability to grow a carapace or regenerate, it makes some sense that they could build into it the ability to see."""
 
 [[Powers]]
@@ -352,18 +347,17 @@ Requires = """
 Eidolon, 20 Ranks in Spellcraft"""
 Effect = """
 you have more Bonuses available. You can select from the following list, as well as the Bonus list above:
-
-- Ethereal: the Eidolon can become intangible for short periods of time. It gains the following Power:
-  - Action: Quick Action
-  - Effect: the Eidolon becomes intangible. Until its next turn, it can pass straight through solid objects, and solid objects will pass through it. This means it cannot be damaged by weapons, but it also means that it cannot (practically) attack other Creatures, or interact with objects.
-- Fire: a fire simmers within the Eidolon, and it can flare forth. The fire provides illumination like a torch. The Eidolon also gains the following Power:
-  - Action: Sustained
-  - Effect: the Eidolon flares forth, becoming a creature of flame. Anything in contact with it suffers 1D10 damage.  Its natural attacks gain the Fire tag, and cause an additional 1D10 DV.
-- Frost: the Eidolon is suffused with frost, appearing to be made from chipped ice. The Eidolon gains +2 Armor and +5 DUR, and it gains the following Power:
-  - Action: Standard
-  - Effect: the Eidolon can freeze something that it touches. Treat this as a Touch-Only Attack. If it hits, the target suffers 1D10 DV.
-- Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
-  - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m"""
+  - Ethereal: the Eidolon can become intangible for short periods of time. It gains the following Power:
+    - Action: Quick Action
+    - Effect: the Eidolon becomes intangible. Until its next turn, it can pass straight through solid objects, and solid objects will pass through it. This means it cannot be damaged by weapons, but it also means that it cannot (practically) attack other Creatures, or interact with objects.
+  - Fire: a fire simmers within the Eidolon, and it can flare forth. The fire provides illumination like a torch. The Eidolon also gains the following Power:
+    - Action: Sustained
+    - Effect: the Eidolon flares forth, becoming a creature of flame. Anything in contact with it suffers 1D10 damage.  Its natural attacks gain the Fire tag, and cause an additional 1D10 DV.
+  - Frost: the Eidolon is suffused with frost, appearing to be made from chipped ice. The Eidolon gains +2 Armor and +5 DUR, and it gains the following Power:
+  -   Action: Standard
+    - Effect: the Eidolon can freeze something that it touches. Treat this as a Touch-Only Attack. If it hits, the target suffers 1D10 DV.
+  - Spines: the Eidolon can launch spines, giving it a potent ranged attack. It gains the following attack:
+    - Attack: Projectile Weapons, 1D10+DB, AP -4. Tags: Natural Weapon. Range: 20m/30m/40m"""
 
 [[Powers]]
 Name = "Eidolons"
@@ -380,19 +374,15 @@ Requires = """
 Eidolon, 20 ranks in Control"""
 Effect = """
 You can fracture your mind, producing a copy of your consciousness for each Eidolon that you have.
-
-- While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
-- It’s still your mind controlling them, so you control them, and you’re aware of what they see and do."""
+  - While sustaining Eidolon, each Eidolon gets its own turn.  They act on your initiative, after your turn.
+  - It’s still your mind controlling them, so you control them, and you’re aware of what they see and do."""
 
 [[Powers]]
 Name = "Protection"
 General = true
-Requires = """
-*Attendant of the Mourner* Class"""
-Action = """
-Sustained"""
-Effect = """
-You gain +3 armor, and those you choose within 5m of you gain +2 armor."""
+Requires = "*Attendant of the Mourner* Class"
+Action = "Sustained"
+Effect = "You gain +3 armor, and those you choose within 5m of you gain +2 armor."
 
 [[Powers]]
 Name = "Rallying Cry"
@@ -402,10 +392,9 @@ Requires = "10 Ranks in a Social Skill, 10 Ranks in a Combat Skill"
 Action = "Quick Action"
 Effect = """
 Roll one of your Social Skills (the GM must approve of your choice).  If you succeed, you *inspire* those nearby (they gain the Brave trait) for 1 turn per 10 points of MoS.
-
-- Normally, you would inspire every ally who can see and hear you, although this might not be the case under unusual circumstances (your GM will decide this).
-- Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all."""
-[[Powers.Section]]
+  - Normally, you would inspire every ally who can see and hear you, although this might not be the case under unusual circumstances (your GM will decide this).
+  - Normally, in order for a character to be inspired, they would need to understand what you are doing — an inspiring speech is useless to someone who doesn't speak your language.  However, some methods of inspiring bravery are universal: delivering a defiant roar can be inspiring without any language or culture in common at all."""
+[[Powers.Sections]]
 Label = "Special"
 Content = """
 The GM may allow you to inspire those around you if you do something particularly heroic: it might be inspiring just to see you burst out of bonds or rise again in spite of grievous wounds."""
@@ -413,12 +402,9 @@ The GM may allow you to inspire those around you if you do something particularl
 [[Powers]]
 Name = "Diving Strike"
 General = true
-Fluff = """
-You've perfected a diving strike, using the momentum of your fall to strengthen your attack."""
-Requires = """
-10 ranks in Athletics, 10 ranks in a *melee combat* skill."""
-Action = """
-Quick Action (Movement)"""
+Fluff = "You've perfected a diving strike, using the momentum of your fall to strengthen your attack."
+Requires = "10 ranks in Athletics, 10 ranks in a *melee combat* skill."
+Action = "Quick Action (Movement)"
 Effect = """
 When you drop down on a target from above, you are considered to be charging; you deal the bonus damage for your charge if you fall more than 1 meter.  (This uses all the normal rules for falling and for charging.)"""
 
@@ -427,24 +413,19 @@ Name = "Reckless Dive"
 General = true
 Fluff = """
 Through some mix of talent, luck, bravery and foolishness, you can drop on targets from great heights, and usually hurt them a lot worse than you hurt yourself."""
-Requires = """
-the *Diving Strike* power, 20 ranks in Athletics"""
+Requires = "the *Diving Strike* power, 20 ranks in Athletics"
 Effect = """
 When you make a Diving Strike, any fall damage that you take is also added to your attack's damage.  (You still take the given fall damage.)
-
-- For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage."""
+  - For example, if you take 1d10 damage from your fall, your attack does 1d10 extra damage."""
 
 [[Powers]]
 Name = "Rough Landing"
 General = true
-Fluff = """
-Luckily, your opponent broke your fall!"""
-Requires = """
-the *Reckless Dive* power, 20 ranks in Athletics"""
+Fluff = "Luckily, your opponent broke your fall!"
+Requires = "the *Reckless Dive* power, 20 ranks in Athletics"
 Effect = """
 When you use your Reckless Dive power, you may reduce the damage that you take by 1d10; your opponent still takes the full falling damage.
-
-- For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage)."""
+  - For example, if you would take 2d10 DV of falling damage, but you make a Diving Strike onto your opponent, then you only take 1d10 DV, but they take your weapon attack, plus 2d10 from the Reckless Dive, plus your DB because your diving strike counts as a charge (since you almost certainly fell more than 1m if you're taking falling damage)."""
 
 [[Powers]]
 Name = "Acrobatic Strike"
@@ -455,8 +436,7 @@ Requires = "20 ranks in Athletics, 10 ranks in a *melee combat* skill."
 Action = "Varies (stunt, movement)"
 Effect = """
 When you make an appropriate *stunt move,* you are considered to be charging.  If you succeed on the movement check required for the stunt (this would normally be an Athletics check for a humanoid character), you deal your charge's bonus damage.
-
-- An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle."""
+  - An "appropriate" stunt move might include kicking off a wall to strike your opponent from above, or making a running dive over an obstacle."""
 
 [[Powers]]
 Name = "Center"
@@ -466,11 +446,11 @@ Slow down.  Take a breath, in and then out.  Forget your cause, forget your oppo
 You have developed a kind of battle-trance, in which your combat instincts are heightened."""
 Requires = """
 10 Ranks in Control, 10 ranks in a combat skill."""
-Action = """
-Sustained."""
+Action = "Sustained."
 Effect = """
-Your Trance Bonus is your equal to your ranks in Control ÷ 10.  You gain your Trance Bonus to your INIT."""
-[[Powers.Section]]
+Your Trance Bonus is your equal to your ranks in Control ÷ 10.
+You gain your Trance Bonus to your INIT."""
+[[Powers.Sections]]
 Label = "Special"
 Content = """
 No Control test is required to activate this power, although one would likely be required to *sustain* it should you suffer a wound, or should some other sufficiently distracting event occur."""
@@ -480,7 +460,7 @@ Name = "Centered Strike"
 General = true
 Fluff = """
 While centered, you strike with extra force."""
-Requirements = """
+Requires = """
 the *Center* power, 20 ranks in Control"""
 Effect = """
 While sustaining Center, You gain +Trance Bonus to your DV."""
@@ -488,19 +468,16 @@ While sustaining Center, You gain +Trance Bonus to your DV."""
 [[Powers]]
 Name = "Centered Defence"
 General = true
-Fluff = """
-While centered, your defence is improved."""
-Requirements = """
-the *Center* power, 20 ranks in Control, 10 ranks in Fray"""
-Effect = """
-While sustaining *Center*, you gain +10 to your defence."""
+Fluff = "While centered, your defence is improved."
+Requires = "the *Center* power, 20 ranks in Control, 10 ranks in Fray"
+Effect = "While sustaining *Center*, you gain +10 to your defence."
 
 [[Powers]]
 Name = "Denial"
 General = true
 Fluff = """
 While in your battle-trance, your defence is nearly perfect."""
-Requirements = """
+Requires = """
 the *Centered Defence* power, 20 ranks in Fray"""
 Effect = """
 If you are subject to an attack that you could defend against with Fray while sustaining Center, you may, as a reaction, have that attack fail.  (Since this is a reaction, you can normally only do this once per turn.)"""
@@ -508,61 +485,50 @@ If you are subject to an attack that you could defend against with Fray while su
 [[Powers]]
 Name = "Shieldwall"
 General = true
-Fluff = """
-You are expert in the use of large shields, and your defence with them is extraordinary."""
-Requirements = """
-20 ranks in Fray"""
+Fluff = "You are expert in the use of large shields, and your defence with them is extraordinary."
+Requires = "20 ranks in Fray"
 Effect = """
 If you are using a Heater Shield, Tower Shield or similar large shield, then, while using a Full Defense action, you are considered to be in cover from direction of your shield.  (This means that you cannot be directly attacked from that side.)
-
-- Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
-- While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)"""
+  - Shieldwall cannot be used to defend against effects that would completely overwhelm you, like large explosions or seige weapons.
+  - While an opponent cannot attack you directly, they might attempt to take the shield from you (by trying to grab it, for example, which might be represented by a Disarm maneuver.)"""
 
 [[Powers]]
 Name = "Brawler's Instinct"
 General = true
 Fluff = """
 Through years of experience with front-line combat, tavern brawls, law enforcement — or only Great Spirits know what else — you've gained a good instinct for when someone is about to start a fight."""
-Requirement = """
-10 ranks in Perception, 10 ranks in two *combat* skills."""
-Effect = """
-You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you."""
+Requires = "10 ranks in Perception, 10 ranks in two *combat* skills."
+Effect = "You do not take the Passive Test penalty to passive Perception and Read tests made against those who are planning to attack you."
 
 [[Powers]]
 Name = "Brawler's Sense"
 General = true
 Fluff = """
 Your fighter's instinct has been honed to the point that it's almost a sixth sense — or seventh or fifth, it depends on how many sense your race normally has..."""
-Requirements = """
+Requires = """
 20 ranks in Perception, 20 ranks in Unarmed Combat"""
 Action = """
 Sustained"""
 Effect = """
 While sustaining this power, you gain *Brawler's Sense* as a sense.
-
-- This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
-- This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
-- What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty."""
+  - This sense allows you to gain enough information about a nearby enemy that you can fight them effectively, even if you can't actually see them.
+  - This sense always requires a perception check to use, and you must have *some* ability to perceive your opponent(s) (like being able to hear or smell them).
+  - What is *nearby* is up to the GM.  Usually, any opponent within 3m is "nearby," and enemies further away may be perceptible with an additional penalty."""
 
 [[Powers]]
 Name = "Bound Fighter"
 General = true
 Fluff = """
 Maybe you've been thrown in jail more than once, maybe this isn't the first meeting you've had with gangsters, or maybe you've been captured before; in any case, you've gotten pretty good at fighting while you're tied up."""
-Requirements = """
-20 ranks in Unarmed Combat"""
-Action = """
-Standard Action"""
-Effect = """
-When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack."""
-[[Powers.Section]]
+Requires = "20 ranks in Unarmed Combat"
+Action = "Standard Action"
+Effect = "When you are *bound*, you can still make an unarmed attack against someone who comes within reach, using all the normal rules for an unarmed attack."
+[[Powers.Sections]]
 Label = "Special"
-Content = """
-You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden."""
-[[Powers.Section]]
+Content = "You can't use this power if you are *completely* bound — such as if you are enclosed in something like an iron maiden."
+[[Powers.Sections]]
 Label = "Special"
-Content = """
-Critical hits with this attack may weaken or break weaker bindings, like ropes."""
+Content = "Critical hits with this attack may weaken or break weaker bindings, like ropes."
 
 [[Powers]]
 Name = "Burried Alive"
@@ -570,39 +536,40 @@ General = true
 Fluff = """
 The stuff of nightmares in Goblinoid territories, a creature that can burrow through the ground can erupt from below and drag an opponent down, partly collapsing the tunnel behind them to trap their victim.
 This can either simply *immobilize* the target, or be rapidly fatal, based on whether or not their head has been buried (or, for non-humanoid creatures, wherever they breath through)."""
-Requirements = "A burrow speed, 20 ranks in Unarmed Combat"
+Requires = "A burrow speed, 20 ranks in Unarmed Combat"
 Action = "Standard Action (Maneuver)"
 Effect = """
-Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.  If you succeed, you haul your target into your tunnel and partially collapse it.  This immobilizes them."""
-[[Powers.Section]]
+Roll your Unarmed Combat, against your opponents Feat of Strength or React Quickly; you suffer a -20 modifier.
+If you succeed, you haul your target into your tunnel and partially collapse it.
+This immobilizes them."""
+[[Powers.Sections]]
 Label = "Special"
 Content = "You must be burrowing near the surface, either adjacent to or directly beneath your opponent to use this power."
-[[Powers.Section]]
+[[Powers.Sections]]
 Label = "Special"
 Content = """
-Instead of immobilizing your opponent, you can instead attempt to completely burry them.  This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate."""
+Instead of immobilizing your opponent, you can instead attempt to completely burry them.
+This is more difficult, so you take an additional -10 penalty; if you succeed, though, they will soon begin to suffocate."""
 
 [[Powers]]
 Name = "Hurl an Ally"
 General = true
 Fluff = """
 You've practice an unusual tactic in which you fling an ally at an enemy; this is sometimes called "the Minotaur and the Frog," after a folk-legend about the tactic's use during a slave revolt in Shade-Elven lands."""
-Requirements = "The *Missile-Hurler* class."
+Requires = "The *Missile-Hurler* class."
 Action = "Standard Action"
 Effect = """
 You can throw an ally.
-
-- They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
-- If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
-- If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
-- If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
-- They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn."""
-[[Powers.Section]]
+  - They must be at least one size category smaller than you (e.g. if you are Medium, you can throw a Small creature).
+  - If you don't throw them farther than your medium range, they can land safely; if you throw them further than your medium range, they take damage as if they had fallen (1d10 DV at long range, 2d10 DV at Extreme range).
+  - If the hurled creature lands at a lower point than when they where thrown, they take appropriate falling damage.
+  - If you throw your ally at an opponent, and if they were prepared for it, then they are considered to have *charged*, and can attack the targeted opponent.
+  - They can prepare as a Standard Action (during their turn), and are then considered to have "prepared" until their next turn."""
+[[Powers.Sections]]
 Label = "Special"
 Content = """
 This power represents *throwing* an ally, which is a Standard Action.
 Much like drawing a weapon, picking up an ally to throw them requires a separate action (normally a Quick Action)."""
-[[Powers.Section]]
+[[Powers.Sections]]
 Label = "Special"
-Content = """
-If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*"""
+Content = "If the hurled ally has the Diving Strike class, they are always considered to be *prepared.*"

--- a/src/datafiles/sed lines.md
+++ b/src/datafiles/sed lines.md
@@ -1,1 +1,0 @@
-sed 's/^- \*\*\(\w\+\)\:\*\*/- \1:/' < powers.mostlymd.dat | sed 's/^- \(\w\+\)\:/\%\1\%\n/' > powers.dat

--- a/src/datafiles/sed lines.md
+++ b/src/datafiles/sed lines.md
@@ -1,0 +1,1 @@
+sed 's/^- \*\*\(\w\+\)\:\*\*/- \1:/' < powers.mostlymd.dat | sed 's/^- \(\w\+\)\:/\%\1\%\n/' > powers.dat


### PR DESCRIPTION
Took a baby-step toward autogenerating our content.

Created a an src/datafiles directory, copied over the markdown from the Powers page, massaged it into a home-rolled format, had an argument with Alexis, botched it into TOML, and wrote a python program to auto-generate the content for the Powers page.

Work to do:
- right now it's manually run; hook it into the actual build process.  (Reason we didn't: toml isn't a core part of python yet, and I don't want to fuck with dependencies.)
- improve the styling; it's not great right now
- possibly add some nice features, like automatic linking of "parent" powers, or automatic building of "power trees"
- replicate this work for some of the other auto-gen-able content (classes, races, items, etc)

Addendum: added two powers I went over with CV.